### PR TITLE
Add grok-2 model definition to xAIModelOptions

### DIFF
--- a/src/vs/workbench/contrib/cortexide/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/cortexide/common/modelCapabilities.ts
@@ -1129,6 +1129,16 @@ const xAIModelOptions = {
 		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canTurnOffReasoning: false, canIOReasoning: false, reasoningSlider: { type: 'effort_slider', values: ['low', 'high'], default: 'low' } },
 	},
+	'grok-2': {
+		contextWindow: 131_072,
+		reservedOutputTokenSpace: null,
+		cost: { input: 2.00, output: 10.00 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
+		reasoningCapabilities: false,
+	},
 } as const satisfies { [s: string]: CortexideStaticModelInfo }
 
 const xAISettings: VoidStaticProviderInfo = {


### PR DESCRIPTION
- Add missing 'grok-2' model configuration to xAIModelOptions
- Fixes TypeScript compilation error where 'grok-2' was referenced in fallback but not defined
- Ensures consistency with defaultModelsOfProvider.xAI list which includes 'grok-2'

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
