### PR TITLE
Fix PR workflows: Replace self-hosted runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/pr-linux-cli-test.yml
+++ b/.github/workflows/pr-linux-cli-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linux-cli-test:
     name: ${{ inputs.job_name }}
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
+    runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: ${{ inputs.rustup_toolchain }}
     steps:

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   linux-test:
     name: ${{ inputs.job_name }}
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
+    runs-on: ubuntu-latest
     env:
       ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
       NPM_ARCH: x64

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   compile:
     name: Compile
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v5
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install build tools
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: sudo apt update -y && sudo apt install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
+        run: sudo apt-get update -y && sudo apt-get install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -86,7 +86,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
+    runs-on: ubuntu-latest
     env:
       NPM_ARCH: x64
       VSCODE_ARCH: x64
@@ -219,7 +219,7 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64 ]
+    runs-on: windows-latest
     env:
       NPM_ARCH: x64
       VSCODE_ARCH: x64

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   windows-test:
     name: ${{ inputs.job_name }}
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64 ]
+    runs-on: windows-latest
     env:
       ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
       NPM_ARCH: x64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   compile:
     name: Compile & Hygiene
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v5
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install build tools
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: sudo apt update -y && sudo apt install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
+        run: sudo apt-get update -y && sudo apt-get install -y build-essential pkg-config libx11-dev libx11-xcb-dev libxkbfile-dev libnotify-bin libkrb5-dev
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
- Updated pr.yml to use ubuntu-latest instead of self-hosted runner
- Updated pr-linux-test.yml to use ubuntu-latest
- Updated pr-linux-cli-test.yml to use ubuntu-latest
- Updated pr-win32-test.yml to use windows-latest
- Updated pr-node-modules.yml to use ubuntu-latest and windows-latest

This fixes workflow failures caused by unavailable Microsoft-specific self-hosted runners in the forked repository.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
