### PR TITLE
fix: add missing X11 dependencies for Linux CI and build dependencies…

### DIFF
--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -45,6 +45,23 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit == 'true'
         run: tar -xzf .build/node_modules_cache/cache.tgz
 
+      - name: Install build dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        working-directory: build
+        run: |
+          set -e
+
+          for i in {1..5}; do # try 5 times
+            npm ci && break
+            if [ $i -eq 5 ]; then
+              echo "Npm install failed too many times" >&2
+              exit 1
+            fi
+            echo "Npm install failed $i, trying again..."
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -39,6 +39,8 @@ jobs:
           ./build/azure-pipelines/linux/apt-retry.sh sudo apt-get install -y pkg-config \
             xvfb \
             libgtk-3-0 \
+            libx11-dev \
+            libx11-xcb-dev \
             libxkbfile-dev \
             libkrb5-dev \
             libgbm1 \


### PR DESCRIPTION
… step for macOS CI

- Add libx11-dev and libx11-xcb-dev to Linux test workflow to fix native-keymap build failure
- Add missing 'Install build dependencies' step to macOS test workflow to ensure build/ folder dependencies are installed before main dependencies

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
