### PR TITLE
fix: stop falsely redacting paths as AWS Secret Key in system message

### DIFF
--- a/src/vs/workbench/contrib/cortexide/common/secretDetection.ts
+++ b/src/vs/workbench/contrib/cortexide/common/secretDetection.ts
@@ -97,11 +97,11 @@ export const DEFAULT_SECRET_PATTERNS: SecretPattern[] = [
 		enabled: true,
 		priority: 100,
 	},
-	// AWS secret keys
+	// AWS secret keys (exclude '/' to avoid false positives on path segments, e.g. prof/cortexide/browser/convertTo)
 	{
 		id: 'aws-secret-key',
 		name: 'AWS Secret Key',
-		pattern: /\b([a-zA-Z0-9/+=]{40})\b/g,
+		pattern: /\b([a-zA-Z0-9+=]{40})\b/g,
 		enabled: true,
 		priority: 85,
 	},


### PR DESCRIPTION
- AWS secret key pattern: remove '/' from character class so path segments (e.g. prof/cortexide/browser/convertTo) are not matched
- Add trace log [SecretDetection] when scanning chat messages so you can verify: 'No secrets detected' or redaction counts by type

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
