### PR TITLE
ci: fix the always-failing PR checks (LFS-404 + upstream-only gating)

### DIFF
--- a/.github/workflows/api-proposal-version-check.yml
+++ b/.github/workflows/api-proposal-version-check.yml
@@ -22,15 +22,19 @@ concurrency:
 jobs:
   check-version-changes:
     name: Check API Proposal Version Changes
-    # Run on PR events, or on issue_comment if it's on a PR and contains the override command
+    # Run on PR events, or on issue_comment if it's on a PR and contains the override command.
+    # Skip on cortexide fork: this check governs upstream's proposed-API
+    # versioning policy. We don't publish proposed APIs from this fork.
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/api-proposal-change-required') &&
-       (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+      github.repository_owner != 'OpenCortexIDE' && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         contains(github.event.comment.body, '/api-proposal-change-required') &&
+         (github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Get PR info

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
+    # Skip on cortexide fork: uses upstream's `vscode-large-runners`
+    # self-hosted runner, which is not available to us.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: vscode-large-runners
 
     # Set the permissions to the lowest permissions possible needed for your steps.

--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -14,6 +14,9 @@ permissions: {}
 jobs:
   main:
     name: Monaco Editor checks
+    # Skip on cortexide fork: Monaco Editor is published from microsoft/vscode;
+    # this check is part of that publishing flow and not relevant downstream.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -21,7 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS objects for the copilot simulation cache are not on our LFS
+          # server. Monaco Editor checks don't need those files anyway.
+          lfs: false
           persist-credentials: false
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -6,6 +6,10 @@ permissions: {}
 jobs:
   main:
     name: Prevent engineering system changes in PRs
+    # Skip on cortexide fork: this check queries microsoft/vscode collaborator
+    # permissions (403 from our token) and enforces upstream's bot policy.
+    # We govern engineering-system changes via PR review on this repo.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: ubuntu-latest
     steps:
       - name: Get file changes

--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: platform test jobs do not exercise the copilot
+          # simulation cache (the only LFS-tracked files in the repo) and our
+          # LFS server returns 404 for those objects.
+          lfs: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-linux-cli-test.yml
+++ b/.github/workflows/pr-linux-cli-test.yml
@@ -18,7 +18,10 @@ jobs:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: the CLI Rust tests do not exercise the copilot
+          # simulation cache (the only LFS-tracked files in the repo) and our
+          # LFS server returns 404 for those objects.
+          lfs: false
 
       - name: Install Rust
         run: |

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: platform test jobs do not exercise the copilot
+          # simulation cache (the only LFS-tracked files in the repo) and our
+          # LFS server returns 404 for those objects.
+          lfs: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: platform test jobs do not exercise the copilot
+          # simulation cache (the only LFS-tracked files in the repo) and our
+          # LFS server returns 404 for those objects.
+          lfs: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: the copilot simulation-cache sqlite pointers in this
+          # repo reference LFS objects that don't exist on our LFS server (404).
+          # Compile/hygiene doesn't touch those files. See PR description.
+          lfs: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -159,6 +162,9 @@ jobs:
 
   copilot-check-test-cache:
     name: Copilot - Check Test Cache
+    # Skip on cortexide fork: this job opens the LFS-stored simulation sqlite
+    # databases, which are not mirrored to our LFS server. Run only on upstream.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -167,7 +173,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: cache-cli check + pr-check-cache-files.ts operate on
+          # file listings / pointer metadata, not blob content. LFS objects for
+          # the copilot simulation cache are not present on our LFS server.
+          lfs: false
 
       - uses: actions/setup-node@v6
         with:
@@ -212,7 +221,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          lfs: true
+          # LFS disabled: telemetry extractor scans TS sources only.
+          lfs: false
 
       - uses: actions/setup-node@v6
         with:
@@ -224,6 +234,9 @@ jobs:
 
   copilot-linux-tests:
     name: Copilot - Test (Linux)
+    # Skip on cortexide fork: simulate-ci depends on LFS-stored simulation cache
+    # databases that are not mirrored to our LFS server. Run only on upstream.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -329,6 +342,9 @@ jobs:
 
   copilot-windows-tests:
     name: Copilot - Test (Windows)
+    # Skip on cortexide fork: simulate-ci depends on LFS-stored simulation cache
+    # databases that are not mirrored to our LFS server. Run only on upstream.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: windows-2022
     permissions:
       contents: read

--- a/.github/workflows/screenshot-test.yml
+++ b/.github/workflows/screenshot-test.yml
@@ -21,6 +21,11 @@ concurrency:
 jobs:
   screenshots:
     name: Checking Component Screenshots
+    # Skip on cortexide fork: this workflow uploads to
+    # hediet-screenshots.azurewebsites.net (upstream's Azure endpoint, returns
+    # 403 for our OIDC token) and posts a comment via the upstream service.
+    # We don't currently run a screenshot diff service.
+    if: github.repository_owner != 'OpenCortexIDE'
     runs-on: ubuntu-latest
     continue-on-error: true # TODO(hediet): Remove once screenshot pipeline is stable
     steps:


### PR DESCRIPTION
## Summary

Every PR on this repo currently shows ~15 red checks. Almost all of them have always been red since long before the 1.118.1 sync (confirmed on PR #44 from Feb 2026). The team has been relying on cortexide-builder for real validation. This PR triages the inherited-from-upstream noise without disabling any check that's catching real regressions.

This is a **draft**; do not merge until reviewed.

## Root causes found

After pulling logs from PRs #46 and #47, the failures collapse into three buckets:

1. **LFS-404 (drives ~15 of the failures).** `actions/checkout@v6` with `lfs: true` fails because every LFS pointer in the repo resolves to 404 on our LFS server:
    ```
    [d326ad15c05a...] Object does not exist on the server: [404]
    error: failed to fetch some objects from 'https://github.com/OpenCortexIDE/cortexide.git/info/lfs'
    The process '/usr/bin/git' failed with exit code 2
    ```
   The only LFS-tracked files in the repo are `extensions/copilot/test/simulation/cache/*.sqlite` (and `extensions/copilot/.gitattributes` declares them). The pointer files are committed; the actual blobs were never uploaded to our LFS endpoint.

2. **Microsoft-specific infrastructure** the fork doesn't have credentials/runners/endpoints for:
   - `Monaco Editor checks` — part of upstream's npm-publish flow for `monaco-editor`.
   - `Prevent engineering system changes in PRs` — queries `microsoft/vscode` collaborator permissions (`403 Resource not accessible by integration`) and references `vs-code-engineering[bot]`.
   - `Check API Proposal Version Changes` — enforces upstream's `vscode.proposed.*.d.ts` versioning policy that we don't manage.
   - `Checking Component Screenshots` — uploads to `hediet-screenshots.azurewebsites.net` with an OIDC token our identity isn't authorized for (`curl: (22) The requested URL returned error: 403`).
   - `copilot-setup-steps` — uses `runs-on: vscode-large-runners` (Microsoft-only self-hosted runner), sits queued 24h before GitHub force-fails it.

3. **Real test failures** — `Component Fixture Tests` is failing 8 Playwright tests in `tests/imageCarousel.spec.ts` (`locator('.image-carousel-editor')` never becomes visible). This fails identically on PR #44 from February, so it's a pre-existing bug unrelated to the 1.118.1 rebase. **Not fixed in this PR**; see follow-ups below.

## Fixes in this PR

| Check | Root cause | Fix |
|---|---|---|
| Compile & Hygiene | LFS-404 | `lfs: false` in pr.yml (compile doesn't read sqlite) |
| Linux / {Browser, Electron, Remote} | LFS-404 | `lfs: false` in pr-linux-test.yml |
| macOS / {Browser, Electron, Remote} | LFS-404 | `lfs: false` in pr-darwin-test.yml |
| Windows / {Browser, Electron, Remote} | LFS-404 | `lfs: false` in pr-win32-test.yml |
| Linux / CLI | LFS-404 | `lfs: false` in pr-linux-cli-test.yml |
| Copilot - Check Telemetry | LFS-404 | `lfs: false` in pr.yml (telemetry extractor reads TS sources) |
| Copilot - Check Test Cache | needs LFS-tracked sqlite | Gated off on fork via `if: github.repository_owner != 'OpenCortexIDE'` |
| Copilot - Test (Linux) | needs LFS-tracked sqlite for simulate-ci | Gated off on fork |
| Copilot - Test (Windows) | needs LFS-tracked sqlite for simulate-ci | Gated off on fork |
| Monaco Editor checks | upstream npm-publish flow + LFS-404 | Gated off on fork |
| Prevent engineering system changes in PRs | queries microsoft/vscode permissions | Gated off on fork |
| Check API Proposal Version Changes | upstream API governance | Gated off on fork |
| Checking Component Screenshots | upstream Azure endpoint (403) | Gated off on fork |
| copilot-setup-steps | uses upstream's self-hosted runner pool | Gated off on fork |

All gating uses `if: github.repository_owner != 'OpenCortexIDE'` so the workflows are kept verbatim and will run normally on any other fork that has the upstream infra. To revert, drop the `if:` line.

## Intentionally NOT fixed

- **`Component Fixture Tests` (Playwright imageCarousel timeouts)** — this is a real test failure, but it pre-existed the rebase by several months and isn't load-bearing for shipping (the actual product build runs in cortexide-builder, which is green). Fixing it requires investigating why `.image-carousel-editor` never mounts in headless Chromium and is out of scope here. Suggest a separate `fix/image-carousel-playwright` PR.
- **`chat-lib tests (ubuntu/macos/windows)`** — these are passing and unaffected.
- **`Check metadata` (telemetry.yml)** — passing.
- **`pr-node-modules.yml`** — push-to-main only, doesn't run on PRs.
- **`sessions-e2e.yml` / `chat-perf.yml`** — already `workflow_dispatch`-only.
- The `cortexide-builder` workflows in the sibling repo were not touched.

## Follow-ups requiring user decision (not in this PR)

1. **LFS data**: do we want to actually upload the copilot simulation sqlite files to our LFS server (~1-2 GB) so the simulate-ci jobs can run? If yes, ungate the three copilot test jobs. If no, leave gated.
2. **Engineering-system guardrail**: upstream's "no PR may modify .github/workflows or build/" rule is a sensible policy. If you want it enforced on this repo too, the workflow could be rewritten to query `OpenCortexIDE/cortexide` collaborator permissions instead of `microsoft/vscode`. Happy to do that in a follow-up.
3. **Screenshot diff service**: if there's appetite, we can stand up our own Azure-Static-Web-Apps screenshot service and re-enable the workflow.

## Test plan

- [ ] Open this draft PR and watch the checks list — only valid checks should run; the gated ones should not appear (or appear as skipped).
- [ ] Confirm `Compile & Hygiene`, `Linux/macOS/Windows × Browser/Electron/Remote`, `Linux / CLI`, and `Copilot - Check Telemetry` all get past `actions/checkout` (they may still fail later for other reasons — that's a separate problem we want to see).
- [ ] Confirm `chat-lib tests` and `Check metadata` still pass.
- [ ] Verify gated workflows show no run for this PR head SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)