### PR TITLE
fix(build): restore type-namespace usage for event-stream

### DIFF
--- a/build/azure-pipelines/upload-cdn.ts
+++ b/build/azure-pipelines/upload-cdn.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import es from '../lib/event-stream-compat.ts';
+import es, { type ThroughStream } from '../lib/event-stream-compat.ts';
 import Vinyl from 'vinyl';
 import vfs from 'vinyl-fs';
 import filter from 'gulp-filter';
@@ -68,7 +68,7 @@ const MimeTypesToCompress = new Set([
 	'text/x-java-source'
 ]);
 
-function wait(stream: es.ThroughStream): Promise<void> {
+function wait(stream: ThroughStream): Promise<void> {
 	return new Promise<void>((c, e) => {
 		stream.on('end', () => c());
 		stream.on('error', (err) => e(err));

--- a/build/lib/event-stream-compat.ts
+++ b/build/lib/event-stream-compat.ts
@@ -10,3 +10,7 @@ import { createRequire } from 'node:module';
 const _require = createRequire(import.meta.url);
 const es = _require('event-stream') as typeof import('event-stream');
 export default es;
+
+// Re-exported as a type so consumers can do `import es, { ThroughStream } from './event-stream-compat.ts'`.
+// A default-imported binding cannot be used as a type namespace under newer tsc.
+export type ThroughStream = import('event-stream').ThroughStream;

--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import es from './event-stream-compat.ts';
+import es, { type ThroughStream } from './event-stream-compat.ts';
 import VinylFile from 'vinyl';
 import log from 'fancy-log';
 import ansiColors from 'ansi-colors';
@@ -18,7 +18,7 @@ export interface IFetchOptions {
 	checksumSha256?: string;
 }
 
-export function fetchUrls(urls: string[] | string, options: IFetchOptions): es.ThroughStream {
+export function fetchUrls(urls: string[] | string, options: IFetchOptions): ThroughStream {
 	if (options === undefined) {
 		options = {};
 	}

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -5,7 +5,7 @@
 
 import path from 'path';
 import fs from 'fs';
-import eventStream from './event-stream-compat.ts';
+import eventStream, { type ThroughStream } from './event-stream-compat.ts';
 import jsonMerge from 'gulp-merge-json';
 import File from 'vinyl';
 import xml2js from 'xml2js';
@@ -329,7 +329,7 @@ function stripComments(content: string): string {
 	return result;
 }
 
-function processCoreBundleFormat(base: string, fileHeader: string, languages: Language[], json: NLSKeysFormat, emitter: eventStream.ThroughStream) {
+function processCoreBundleFormat(base: string, fileHeader: string, languages: Language[], json: NLSKeysFormat, emitter: ThroughStream) {
 	const languageDirectory = path.join(REPO_ROOT_PATH, '..', 'vscode-loc', 'i18n');
 	if (!fs.existsSync(languageDirectory)) {
 		log(`No VS Code localization repository found. Looking at ${languageDirectory}`);
@@ -369,8 +369,8 @@ globalThis._VSCODE_NLS_LANGUAGE=${JSON.stringify(language.id)};`),
 	});
 }
 
-export function processNlsFiles(opts: { out: string; fileHeader: string; languages: Language[] }): eventStream.ThroughStream {
-	return eventStream.through(function (this: eventStream.ThroughStream, file: File) {
+export function processNlsFiles(opts: { out: string; fileHeader: string; languages: Language[] }): ThroughStream {
+	return eventStream.through(function (this: ThroughStream, file: File) {
 		const fileName = path.basename(file.path);
 		if (fileName === 'nls.keys.json') {
 			try {
@@ -428,8 +428,8 @@ export function getResource(sourceFile: string): Resource {
 }
 
 
-export function createXlfFilesForCoreBundle(): eventStream.ThroughStream {
-	return eventStream.through(function (this: eventStream.ThroughStream, file: File) {
+export function createXlfFilesForCoreBundle(): ThroughStream {
+	return eventStream.through(function (this: ThroughStream, file: File) {
 		const basename = path.basename(file.path);
 		if (basename === 'nls.metadata.json') {
 			if (file.isBuffer()) {
@@ -544,11 +544,11 @@ export const EXTERNAL_EXTENSIONS = [
 	'ms-vscode.vscode-js-profile-table',
 ];
 
-export function createXlfFilesForExtensions(): eventStream.ThroughStream {
+export function createXlfFilesForExtensions(): ThroughStream {
 	let counter: number = 0;
 	let folderStreamEnded: boolean = false;
 	let folderStreamEndEmitted: boolean = false;
-	return eventStream.through(function (this: eventStream.ThroughStream, extensionFolder: File) {
+	return eventStream.through(function (this: ThroughStream, extensionFolder: File) {
 		const folderStream = this;
 		const stat = fs.statSync(extensionFolder.path);
 		if (!stat.isDirectory()) {
@@ -629,8 +629,8 @@ export function createXlfFilesForExtensions(): eventStream.ThroughStream {
 	});
 }
 
-export function createXlfFilesForIsl(): eventStream.ThroughStream {
-	return eventStream.through(function (this: eventStream.ThroughStream, file: File) {
+export function createXlfFilesForIsl(): ThroughStream {
+	return eventStream.through(function (this: ThroughStream, file: File) {
 		let projectName: string,
 			resourceFile: string;
 		if (path.basename(file.path) === 'messages.en.isl') {
@@ -736,7 +736,7 @@ export function prepareI18nPackFiles(resultingTranslationPaths: TranslationPath[
 	const mainPack: I18nPack = { version: i18nPackVersion, contents: {} };
 	const extensionsPacks: Record<string, I18nPack> = {};
 	const errors: unknown[] = [];
-	return eventStream.through(function (this: eventStream.ThroughStream, xlf: File) {
+	return eventStream.through(function (this: ThroughStream, xlf: File) {
 		let project = path.basename(path.dirname(path.dirname(xlf.relative)));
 		// strip `-new` since vscode-extensions-loc uses the `-new` suffix to indicate that it's from the new loc pipeline
 		const resource = path.basename(path.basename(xlf.relative, '.xlf'), '-new');
@@ -798,10 +798,10 @@ export function prepareI18nPackFiles(resultingTranslationPaths: TranslationPath[
 	});
 }
 
-export function prepareIslFiles(language: Language, innoSetupConfig: InnoSetup): eventStream.ThroughStream {
+export function prepareIslFiles(language: Language, innoSetupConfig: InnoSetup): ThroughStream {
 	const parsePromises: Promise<l10nJsonDetails[]>[] = [];
 
-	return eventStream.through(function (this: eventStream.ThroughStream, xlf: File) {
+	return eventStream.through(function (this: ThroughStream, xlf: File) {
 		const stream = this;
 		const parsePromise = XLF.parse(xlf.contents!.toString());
 		parsePromises.push(parsePromise);

--- a/build/lib/stats.ts
+++ b/build/lib/stats.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import es from './event-stream-compat.ts';
+import es, { type ThroughStream } from './event-stream-compat.ts';
 import fancyLog from 'fancy-log';
 import ansiColors from 'ansi-colors';
 import File from 'vinyl';
@@ -43,7 +43,7 @@ class Entry {
 
 const _entries = new Map<string, Entry>();
 
-export function createStatsStream(group: string, log?: boolean): es.ThroughStream {
+export function createStatsStream(group: string, log?: boolean): ThroughStream {
 
 	const entry = new Entry(group, 0, 0);
 	_entries.set(entry.name, entry);

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -13,7 +13,7 @@ import fs from 'fs';
 import VinylFile from 'vinyl';
 import through from 'through';
 import sm from 'source-map';
-import { pathToFileURL, fileURLToPath } from 'url';
+import { pathToFileURL } from 'url';
 import { createRequire } from 'module';
 import ternaryStream from 'ternary-stream';
 import type { Transform } from 'stream';


### PR DESCRIPTION
## Summary

Fixes the `Type check /build/ scripts` failure that's been red on every PR since the VS Code 1.118.1 merge.

## Root cause

`build/lib/event-stream-compat.ts` re-exports `event-stream` as a default value (`export default es`) so the runtime ESM/CJS interop workaround keeps working. Newer `tsc` (the version invoked by `npx tsgo`) rejects using a default-imported binding as a **type namespace**, so the following pattern stops compiling:

```ts
import es from './event-stream-compat.ts';
function foo(): es.ThroughStream { ... }   // TS2503: Cannot find namespace 'es'
```

17 errors in 5 files, all variants of this (12 in `i18n.ts`, plus `fetch.ts`, `stats.ts`, `upload-cdn.ts`, plus 1 unused-import in `util.ts`).

Upstream microsoft/vscode 1.118.1 doesn't hit this because it does `import es from 'event-stream'` directly — the `event-stream` package's own types include the namespace shape. Our compat shim narrows the type to `typeof import('event-stream')` which is the value shape only.

## Fix

- `event-stream-compat.ts`: re-export `ThroughStream` as a named type so consumers can `import es, { ThroughStream } from './event-stream-compat.ts'`. Only one namespace type was actually referenced across all five files.
- 4 consumer files: add the named type to their import and replace `(es|eventStream).ThroughStream` → `ThroughStream`. `es.through()` / `eventStream.through()` value calls in function bodies are unchanged.
- `util.ts`: remove unused `fileURLToPath` from the `'url'` import (separate TS6133).

## Verification

Ran the exact CI command locally:
```
npx tsgo --project build/tsconfig.json
```
All 17 originally-failing errors now clear. (5 unrelated `Cannot find module` errors for `zx`/`@rspack/core`/`@vscode/component-explorer-webpack-plugin` show locally because I haven't run `npm install` in `build/rspack/`; those resolve in CI — they weren't in PR #48's failure list.)

## Constraints honored

- Touched only files under `build/`.
- Did not bump `event-stream`, `@types/event-stream`, or any dep version.
- No `--no-verify`; husky pre-commit hygiene ran.
- Draft PR; no merge.

## Closes

Last gap from the [PR #48 follow-up list](https://github.com/OpenCortexIDE/cortexide/pull/48) — the build-script TypeScript errors. Independent of the `imageCarousel.spec.ts` Playwright failures noted there.