### PR TITLE
feat(onboarding): zero-friction express path with local-first + Groq fallback

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/ExpressOnboardingFlow.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/ExpressOnboardingFlow.tsx
@@ -1,0 +1,605 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *
+ *  ExpressOnboardingFlow
+ *  ---------------------
+ *  The "zero-friction" express path. Renders by default on first launch when
+ *  the user has no provider configured. Goal: working chat in ~90s, no
+ *  settings touched.
+ *
+ *  Flow:
+ *    1.  Detect Ollama + hardware (in parallel).
+ *    2.  If Ollama already running -> auto-pull the hw-recommended pack.
+ *    3.  If Ollama not running    -> show ONE confirmation modal asking to install,
+ *                                    OR offer the Groq free-tier fallback.
+ *    4.  When pull completes      -> set the freshly-pulled model as the active
+ *                                    Chat model and mark onboarding complete.
+ *    5.  Groq fallback page       -> deep-links to console.groq.com/keys, exposes
+ *                                    a paste box, persists the key via
+ *                                    ICortexideSettingsService, completes onboarding.
+ *
+ *  Power users can always click "Customize setup" to launch the full LocalSetupWizard.
+ *
+ *  No telemetry events are fired from this component (privacy-first).
+ *--------------------------------------------------------------------------------------*/
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, Cpu, ExternalLink, Loader2, Settings, X, Zap } from 'lucide-react';
+import { useAccessor } from '../util/services.js';
+import { useTranslation } from '../util/useTranslation.js';
+import { MODEL_PACKS, type ModelPackKey } from '../../../../common/ollamaInstallerService.js';
+import { LocalSetupWizard } from './LocalSetupWizard.js';
+import ErrorBoundary from '../sidebar-tsx/ErrorBoundary.js';
+
+type Phase =
+	| 'detecting'
+	| 'awaiting-install-confirm'
+	| 'installing'
+	| 'pulling'
+	| 'ready'
+	| 'groq-fallback'
+	| 'error-install'
+	| 'error-pull';
+
+type Hardware = { vramGB: number | null; recommendedPack: ModelPackKey };
+
+interface ExpressOnboardingFlowProps {
+	onCustomize: () => void;
+	onDismiss: () => void;
+}
+
+const GROQ_KEYS_URL = 'https://console.groq.com/keys';
+// Conservative, well-supported free-tier default. Keep in sync with
+// common/modelCapabilities.ts groq model list.
+const GROQ_DEFAULT_MODEL = 'llama-3.3-70b-versatile';
+
+const interpolate = (template: string, ...args: (string | number)[]): string => {
+	return template.replace(/\{(\d+)\}/g, (_, idx) => String(args[Number(idx)] ?? ''));
+};
+
+export const ExpressOnboardingFlow = ({ onCustomize, onDismiss }: ExpressOnboardingFlowProps) => {
+	const { t } = useTranslation();
+	const accessor = useAccessor();
+	const settingsService = accessor.get('ICortexideSettingsService');
+	const ollamaInstaller = accessor.get('OllamaInstallerService');
+
+	const [phase, setPhase] = useState<Phase>('detecting');
+	const [hardware, setHardware] = useState<Hardware | null>(null);
+	const [progressPercent, setProgressPercent] = useState<number>(0);
+	const [progressStatus, setProgressStatus] = useState<string>('');
+	const [groqApiKey, setGroqApiKey] = useState<string>('');
+	const [groqError, setGroqError] = useState<string | null>(null);
+	const [showLocalWizard, setShowLocalWizard] = useState<boolean>(false);
+
+	// Track timers / subscriptions for clean disposal.
+	const disposablesRef = useRef<Array<() => void>>([]);
+	const installInFlightRef = useRef<boolean>(false);
+
+	const chosenPack = useMemo(() => {
+		const key: ModelPackKey = hardware?.recommendedPack ?? 'fast';
+		return { key, ...MODEL_PACKS[key] };
+	}, [hardware]);
+
+	// Cleanup any subscriptions / timers on unmount.
+	useEffect(() => {
+		return () => {
+			for (const dispose of disposablesRef.current) {
+				try { dispose(); } catch { /* swallow */ }
+			}
+			disposablesRef.current = [];
+		};
+	}, []);
+
+	// Step 1: detect hardware + check if Ollama is already running.
+	useEffect(() => {
+		if (!ollamaInstaller) {
+			// No installer service -> fall straight back to Groq.
+			setPhase('groq-fallback');
+			return;
+		}
+
+		let cancelled = false;
+
+		(async () => {
+			try {
+				const [hw, running] = await Promise.all([
+					ollamaInstaller.getHardwareInfo().catch(() => ({ vramGB: null, recommendedPack: 'fast' as ModelPackKey })),
+					ollamaInstaller.isOllamaRunning().catch(() => false),
+				]);
+				if (cancelled) return;
+				setHardware(hw);
+				if (running) {
+					// Ollama already running -> skip the install prompt entirely.
+					await startPull(hw.recommendedPack);
+				} else {
+					setPhase('awaiting-install-confirm');
+				}
+			} catch {
+				if (!cancelled) setPhase('groq-fallback');
+			}
+		})();
+
+		return () => { cancelled = true; };
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ollamaInstaller]);
+
+	const startPull = async (packKey: ModelPackKey) => {
+		if (!ollamaInstaller) {
+			setPhase('groq-fallback');
+			return;
+		}
+		const pack = MODEL_PACKS[packKey];
+		setPhase('pulling');
+		setProgressPercent(0);
+		setProgressStatus('');
+
+		const progressSub = ollamaInstaller.onPullProgress(({ percent, status }) => {
+			setProgressPercent(percent);
+			setProgressStatus(status);
+		});
+		disposablesRef.current.push(() => progressSub.dispose());
+
+		try {
+			await ollamaInstaller.pullModel(pack.tag);
+			// Pull completed -> mark agent ready: add model to ollama provider,
+			// select it for Chat, persist onboarding complete.
+			// (_didFillInProviderSettings auto-recomputes inside the settings
+			// service because ollama only requires `endpoint`, which has a
+			// non-empty default.)
+			settingsService.addModel('ollama', pack.tag);
+			await settingsService.setModelSelectionOfFeature('Chat', { providerName: 'ollama', modelName: pack.tag });
+			settingsService.setGlobalSetting('isOnboardingComplete', true);
+			setPhase('ready');
+		} catch (e) {
+			console.error('[Express onboarding] Pull failed:', e);
+			setPhase('error-pull');
+		}
+	};
+
+	const handleConfirmInstall = async () => {
+		if (!ollamaInstaller || installInFlightRef.current) return;
+		installInFlightRef.current = true;
+		setPhase('installing');
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				const doneSub = ollamaInstaller.onDone((ok) => {
+					doneSub.dispose();
+					if (ok) resolve();
+					else reject(new Error('Ollama install reported failure'));
+				});
+				disposablesRef.current.push(() => doneSub.dispose());
+				ollamaInstaller.install({ method: 'auto' });
+			});
+
+			// Re-check health: install completion does not always equal daemon
+			// reachable. Give it up to ~15s before giving up.
+			const ready = await waitForOllamaReady(ollamaInstaller, 15);
+			if (!ready) throw new Error('Ollama installed but daemon not reachable');
+
+			// Re-resolve hardware in case detection failed earlier (no GPU drivers
+			// before install, etc.). Fall back to the existing recommendation.
+			const hwNext = hardware ?? await ollamaInstaller.getHardwareInfo().catch(() => ({ vramGB: null, recommendedPack: 'fast' as ModelPackKey }));
+			if (!hardware) setHardware(hwNext);
+			await startPull(hwNext.recommendedPack);
+		} catch (e) {
+			console.error('[Express onboarding] Install failed:', e);
+			setPhase('error-install');
+		} finally {
+			installInFlightRef.current = false;
+		}
+	};
+
+	const handleDeclineInstall = () => {
+		setPhase('groq-fallback');
+	};
+
+	const handleUseGroqKey = async () => {
+		const trimmed = groqApiKey.trim();
+		if (!trimmed.startsWith('gsk_') || trimmed.length < 20) {
+			setGroqError(t('express.invalidKey'));
+			return;
+		}
+		setGroqError(null);
+		try {
+			await settingsService.setSettingOfProvider('groq', 'apiKey', trimmed);
+			settingsService.addModel('groq', GROQ_DEFAULT_MODEL);
+			await settingsService.setModelSelectionOfFeature('Chat', { providerName: 'groq', modelName: GROQ_DEFAULT_MODEL });
+			settingsService.setGlobalSetting('isOnboardingComplete', true);
+			setPhase('ready');
+		} catch (e) {
+			console.error('[Express onboarding] Groq key save failed:', e);
+			setGroqError(t('common.error'));
+		}
+	};
+
+	const handleStartChatting = () => {
+		// Settings already persisted; just close the UI.
+		onDismiss();
+	};
+
+	// --- Power-user escape hatch: full LocalSetupWizard ---
+	if (showLocalWizard) {
+		return (
+			<ErrorBoundary>
+				<LocalSetupWizard
+					onComplete={() => { setShowLocalWizard(false); onDismiss(); }}
+					onSkip={() => setShowLocalWizard(false)}
+				/>
+			</ErrorBoundary>
+		);
+	}
+
+	return (
+		<ExpressShell onCustomize={() => setShowLocalWizard(true)} onDismiss={onDismiss}>
+			{phase === 'detecting' && <DetectingPanel t={t} />}
+			{phase === 'awaiting-install-confirm' && (
+				<InstallConfirmPanel
+					t={t}
+					hardware={hardware}
+					pack={chosenPack}
+					onConfirm={handleConfirmInstall}
+					onDecline={handleDeclineInstall}
+				/>
+			)}
+			{phase === 'installing' && <InstallingPanel t={t} />}
+			{phase === 'pulling' && (
+				<PullingPanel
+					t={t}
+					modelTag={chosenPack.tag}
+					percent={progressPercent}
+					status={progressStatus}
+				/>
+			)}
+			{phase === 'ready' && (
+				<ReadyPanel t={t} onStart={handleStartChatting} />
+			)}
+			{phase === 'groq-fallback' && (
+				<GroqFallbackPanel
+					t={t}
+					apiKey={groqApiKey}
+					onApiKeyChange={(v) => { setGroqApiKey(v); if (groqError) setGroqError(null); }}
+					onSubmit={handleUseGroqKey}
+					errorMessage={groqError}
+				/>
+			)}
+			{phase === 'error-install' && (
+				<ErrorPanel
+					t={t}
+					message={t('express.error.installFailed')}
+					onRetry={handleConfirmInstall}
+					onFallback={() => setPhase('groq-fallback')}
+				/>
+			)}
+			{phase === 'error-pull' && (
+				<ErrorPanel
+					t={t}
+					message={t('express.error.pullFailed')}
+					onRetry={() => startPull(chosenPack.key)}
+					onFallback={() => setPhase('groq-fallback')}
+				/>
+			)}
+		</ExpressShell>
+	);
+};
+
+// allow-any-unicode-next-line
+// ─── helper: poll for Ollama health ──────────────────────────────────────────
+
+const waitForOllamaReady = async (
+	installer: { isOllamaRunning(): Promise<boolean> },
+	timeoutSeconds: number,
+): Promise<boolean> => {
+	const deadline = Date.now() + timeoutSeconds * 1000;
+	while (Date.now() < deadline) {
+		if (await installer.isOllamaRunning().catch(() => false)) return true;
+		await new Promise<void>(r => setTimeout(r, 1000));
+	}
+	return false;
+};
+
+// allow-any-unicode-next-line
+// ─── presentational sub-components ───────────────────────────────────────────
+
+const ExpressShell = ({ children, onCustomize, onDismiss }: {
+	children: React.ReactNode;
+	onCustomize: () => void;
+	onDismiss: () => void;
+}) => {
+	const { t } = useTranslation();
+	return (
+		<div
+			className="w-full max-w-[640px] mx-auto rounded-[28px] border p-8 backdrop-blur-xl"
+			style={{
+				borderColor: 'var(--cortex-border-3, rgba(255,255,255,0.1))',
+				background: 'var(--cortex-bg-2, rgba(15,15,20,0.72))',
+				boxShadow: '0 40px 110px rgba(0,0,0,0.55)',
+			}}
+		>
+			<div className="flex items-start justify-between mb-6">
+				<div className="flex items-center gap-3">
+					<div
+						className="w-10 h-10 rounded-2xl flex items-center justify-center"
+						style={{ background: 'var(--cortex-brand, #6b5bff)' }}
+					>
+						<Zap className="w-5 h-5 text-white" />
+					</div>
+					<div>
+						<h1 className="text-xl font-semibold" style={{ color: 'var(--cortex-fg-0, #ffffff)' }}>
+							{t('express.title')}
+						</h1>
+						<p className="text-sm mt-0.5" style={{ color: 'var(--cortex-fg-3, rgba(255,255,255,0.6))' }}>
+							{t('express.subtitle')}
+						</p>
+					</div>
+				</div>
+				<button
+					type="button"
+					onClick={onDismiss}
+					aria-label={t('express.dismiss')}
+					className="p-2 rounded-xl transition-colors"
+					style={{ color: 'var(--cortex-fg-3, rgba(255,255,255,0.6))' }}
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+
+			<div className="mb-6">{children}</div>
+
+			<div
+				className="flex items-center justify-between pt-4 border-t"
+				style={{ borderColor: 'var(--cortex-border-4, rgba(255,255,255,0.06))' }}
+			>
+				<button
+					type="button"
+					onClick={onCustomize}
+					className="inline-flex items-center gap-2 text-xs font-medium transition-colors"
+					style={{ color: 'var(--cortex-fg-3, rgba(255,255,255,0.6))' }}
+				>
+					<Settings className="w-3.5 h-3.5" />
+					{t('express.customize')}
+				</button>
+				<button
+					type="button"
+					onClick={onDismiss}
+					className="text-xs font-medium transition-colors"
+					style={{ color: 'var(--cortex-fg-4, rgba(255,255,255,0.45))' }}
+				>
+					{t('express.dismiss')}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+const DetectingPanel = ({ t }: { t: ReturnType<typeof useTranslation>['t'] }) => (
+	<div className="flex items-center gap-3">
+		<Loader2 className="w-5 h-5 animate-spin" style={{ color: 'var(--cortex-brand, #6b5bff)' }} />
+		<span style={{ color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))' }}>{t('express.detecting')}</span>
+	</div>
+);
+
+const InstallConfirmPanel = ({ t, hardware, pack, onConfirm, onDecline }: {
+	t: ReturnType<typeof useTranslation>['t'];
+	hardware: Hardware | null;
+	pack: { key: ModelPackKey; tag: string; label: string; description: string };
+	onConfirm: () => void;
+	onDecline: () => void;
+}) => (
+	<div className="space-y-5">
+		{hardware && (
+			<div
+				className="flex items-center gap-2 px-3 py-2 rounded-xl text-sm"
+				style={{
+					background: 'var(--cortex-bg-3, rgba(255,255,255,0.04))',
+					color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))',
+				}}
+			>
+				<Cpu className="w-4 h-4" style={{ color: 'var(--cortex-brand, #6b5bff)' }} />
+				<span>
+					{hardware.vramGB != null
+						? interpolate(t('express.detected'), hardware.vramGB)
+						: t('express.detectedNoGPU')}
+				</span>
+			</div>
+		)}
+		<div>
+			<h2 className="text-lg font-semibold mb-2" style={{ color: 'var(--cortex-fg-0, #ffffff)' }}>
+				{t('express.installPromptTitle')}
+			</h2>
+			<p className="text-sm" style={{ color: 'var(--cortex-fg-3, rgba(255,255,255,0.6))' }}>
+				{t('express.installPromptBody')}
+			</p>
+			<p className="text-xs mt-3" style={{ color: 'var(--cortex-fg-4, rgba(255,255,255,0.45))' }}>
+				{pack.label} ({pack.tag}) - {pack.description}
+			</p>
+		</div>
+		<div className="flex flex-col sm:flex-row gap-2">
+			<button
+				type="button"
+				onClick={onConfirm}
+				className="flex-1 px-4 py-2.5 rounded-xl font-medium text-white transition-transform hover:translate-y-[-1px]"
+				style={{ background: 'var(--cortex-brand, #6b5bff)' }}
+			>
+				{t('express.installConfirm')}
+			</button>
+			<button
+				type="button"
+				onClick={onDecline}
+				className="flex-1 px-4 py-2.5 rounded-xl font-medium transition-colors"
+				style={{
+					border: '1px solid var(--cortex-border-3, rgba(255,255,255,0.1))',
+					color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))',
+				}}
+			>
+				{t('express.installDecline')}
+			</button>
+		</div>
+	</div>
+);
+
+const InstallingPanel = ({ t }: { t: ReturnType<typeof useTranslation>['t'] }) => (
+	<div className="flex items-center gap-3">
+		<Loader2 className="w-5 h-5 animate-spin" style={{ color: 'var(--cortex-brand, #6b5bff)' }} />
+		<span style={{ color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))' }}>{t('express.installing')}</span>
+	</div>
+);
+
+const PullingPanel = ({ t, modelTag, percent, status }: {
+	t: ReturnType<typeof useTranslation>['t'];
+	modelTag: string;
+	percent: number;
+	status: string;
+}) => (
+	<div className="space-y-4">
+		<div className="flex items-center gap-3">
+			<Loader2 className="w-5 h-5 animate-spin" style={{ color: 'var(--cortex-brand, #6b5bff)' }} />
+			<span style={{ color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))' }}>
+				{interpolate(t('express.pullingPercent'), modelTag, percent)}
+			</span>
+		</div>
+		<div
+			className="w-full h-2 rounded-full overflow-hidden"
+			style={{ background: 'var(--cortex-bg-3, rgba(255,255,255,0.06))' }}
+		>
+			<div
+				className="h-full rounded-full transition-all duration-300"
+				style={{
+					width: `${Math.min(100, Math.max(0, percent))}%`,
+					background: 'var(--cortex-brand, #6b5bff)',
+				}}
+			/>
+		</div>
+		{status && (
+			<div className="text-xs" style={{ color: 'var(--cortex-fg-4, rgba(255,255,255,0.45))' }}>
+				{status}
+			</div>
+		)}
+	</div>
+);
+
+const ReadyPanel = ({ t, onStart }: {
+	t: ReturnType<typeof useTranslation>['t'];
+	onStart: () => void;
+}) => (
+	<div className="space-y-4">
+		<div className="flex items-center gap-3">
+			<div
+				className="w-9 h-9 rounded-xl flex items-center justify-center"
+				style={{ background: 'rgba(16, 185, 129, 0.18)' }}
+			>
+				<Check className="w-5 h-5" style={{ color: 'rgb(52, 211, 153)' }} />
+			</div>
+			<span className="text-base font-medium" style={{ color: 'var(--cortex-fg-0, #ffffff)' }}>
+				{t('express.ready')}
+			</span>
+		</div>
+		<button
+			type="button"
+			onClick={onStart}
+			className="w-full px-4 py-2.5 rounded-xl font-medium text-white transition-transform hover:translate-y-[-1px]"
+			style={{ background: 'var(--cortex-brand, #6b5bff)' }}
+		>
+			{t('express.startChatting')}
+		</button>
+	</div>
+);
+
+const GroqFallbackPanel = ({ t, apiKey, onApiKeyChange, onSubmit, errorMessage }: {
+	t: ReturnType<typeof useTranslation>['t'];
+	apiKey: string;
+	onApiKeyChange: (v: string) => void;
+	onSubmit: () => void;
+	errorMessage: string | null;
+}) => (
+	<div className="space-y-5">
+		<div>
+			<h2 className="text-lg font-semibold mb-2" style={{ color: 'var(--cortex-fg-0, #ffffff)' }}>
+				{t('express.fallbackTitle')}
+			</h2>
+			<p className="text-sm" style={{ color: 'var(--cortex-fg-3, rgba(255,255,255,0.6))' }}>
+				{t('express.fallbackBody')}
+			</p>
+		</div>
+
+		<a
+			href={GROQ_KEYS_URL}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium transition-colors"
+			style={{
+				border: '1px solid var(--cortex-border-3, rgba(255,255,255,0.1))',
+				color: 'var(--cortex-fg-1, rgba(255,255,255,0.9))',
+				background: 'var(--cortex-bg-3, rgba(255,255,255,0.04))',
+			}}
+		>
+			<ExternalLink className="w-4 h-4" />
+			{t('express.openGroqKeyPage')}
+		</a>
+
+		<div className="space-y-2">
+			<input
+				type="password"
+				autoComplete="off"
+				spellCheck={false}
+				value={apiKey}
+				onChange={(e) => onApiKeyChange(e.target.value)}
+				placeholder={t('express.pasteKeyPlaceholder')}
+				className="w-full px-3 py-2.5 rounded-xl text-sm font-mono outline-none"
+				style={{
+					background: 'var(--cortex-bg-3, rgba(255,255,255,0.04))',
+					border: '1px solid var(--cortex-border-3, rgba(255,255,255,0.1))',
+					color: 'var(--cortex-fg-0, #ffffff)',
+				}}
+			/>
+			{errorMessage && (
+				<p className="text-xs" style={{ color: 'rgb(248, 113, 113)' }}>{errorMessage}</p>
+			)}
+		</div>
+
+		<button
+			type="button"
+			onClick={onSubmit}
+			disabled={!apiKey.trim()}
+			className="w-full px-4 py-2.5 rounded-xl font-medium text-white transition-transform disabled:opacity-50 disabled:cursor-not-allowed enabled:hover:translate-y-[-1px]"
+			style={{ background: 'var(--cortex-brand, #6b5bff)' }}
+		>
+			{t('express.useGroqKey')}
+		</button>
+	</div>
+);
+
+const ErrorPanel = ({ t, message, onRetry, onFallback }: {
+	t: ReturnType<typeof useTranslation>['t'];
+	message: string;
+	onRetry: () => void;
+	onFallback: () => void;
+}) => (
+	<div className="space-y-4">
+		<p className="text-sm" style={{ color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))' }}>
+			{message}
+		</p>
+		<div className="flex flex-col sm:flex-row gap-2">
+			<button
+				type="button"
+				onClick={onRetry}
+				className="flex-1 px-4 py-2.5 rounded-xl font-medium text-white transition-transform hover:translate-y-[-1px]"
+				style={{ background: 'var(--cortex-brand, #6b5bff)' }}
+			>
+				{t('express.retry')}
+			</button>
+			<button
+				type="button"
+				onClick={onFallback}
+				className="flex-1 px-4 py-2.5 rounded-xl font-medium transition-colors"
+				style={{
+					border: '1px solid var(--cortex-border-3, rgba(255,255,255,0.1))',
+					color: 'var(--cortex-fg-2, rgba(255,255,255,0.8))',
+				}}
+			>
+				{t('express.useCloudInstead')}
+			</button>
+		</div>
+	</div>
+);

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/VoidOnboarding.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/VoidOnboarding.tsx
@@ -15,6 +15,7 @@ import { ColorScheme } from '../../../../../../../platform/theme/common/theme.js
 import ErrorBoundary from '../sidebar-tsx/ErrorBoundary.js';
 import { FileAccess } from '../../../../../../../base/common/network.js';
 import { LocalSetupWizard } from './LocalSetupWizard.js';
+import { ExpressOnboardingFlow } from './ExpressOnboardingFlow.js';
 
 const OVERRIDE_VALUE = false
 
@@ -34,12 +35,37 @@ const welcomeStats = [
 	{ label: 'Agent tools', value: '27 built-ins', detail: 'File edits, terminal, web search, LSP navigation, code review, and more' },
 ];
 
+// Returns true if the user has configured at least one provider with a complete
+// set of fields. Used to decide whether to show the express path (no provider yet)
+// or fall back to the full multi-step wizard (user has started configuring providers).
+const userHasAnyProvider = (state: ReturnType<typeof useSettingsState>): boolean => {
+	const providers = state.settingsOfProvider as Record<string, { _didFillInProviderSettings?: boolean }>;
+	for (const key of Object.keys(providers)) {
+		if (providers[key]?._didFillInProviderSettings) return true;
+	}
+	return false;
+}
+
 export const VoidOnboarding = () => {
+
+	const accessor = useAccessor()
+	const settingsService = accessor.get('ICortexideSettingsService')
 
 	const voidSettingsState = useSettingsState()
 	const isOnboardingComplete = voidSettingsState.globalSettings.isOnboardingComplete || OVERRIDE_VALUE
 
 	const isDark = useIsDark()
+
+	// "Use the full guided wizard" escape hatch — flips the express UI off
+	// for power users who want the legacy multi-step flow.
+	const [useExpressFlow, setUseExpressFlow] = useState<boolean>(true)
+
+	const hasAnyProvider = userHasAnyProvider(voidSettingsState)
+	// Express path is the default when:
+	//   - onboarding is incomplete, AND
+	//   - no provider is configured yet (i.e. genuine first-launch), AND
+	//   - the user has not opted into the legacy wizard.
+	const showExpressFlow = useExpressFlow && !isOnboardingComplete && !hasAnyProvider
 
 	return (
 		<div className={`@@void-scope ${isDark ? 'dark' : ''}`}>
@@ -58,7 +84,19 @@ export const VoidOnboarding = () => {
 			>
 				<ErrorBoundary>
 					<div className="w-full max-w-[1200px] py-6">
-						<VoidOnboardingContent />
+						{showExpressFlow ? (
+							<ExpressOnboardingFlow
+								onCustomize={() => setUseExpressFlow(false)}
+								onDismiss={() => {
+									// "Skip for now" / "Start chatting" - mark onboarding complete so
+									// the overlay closes. The full settings pane remains reachable
+									// for later configuration.
+									settingsService.setGlobalSetting('isOnboardingComplete', true)
+								}}
+							/>
+						) : (
+							<VoidOnboardingContent />
+						)}
 					</div>
 				</ErrorBoundary>
 			</div>

--- a/src/vs/workbench/contrib/cortexide/common/i18n/i18nService.ts
+++ b/src/vs/workbench/contrib/cortexide/common/i18n/i18nService.ts
@@ -140,6 +140,35 @@ export const EN_TRANSLATIONS = {
 	'onboarding.headline': 'Build with the editor AI actually ships in',
 
 	// allow-any-unicode-next-line
+	// ── Express onboarding (zero-friction path) ───────────────────────────────
+	'express.title': 'Setting up local AI…',
+	'express.subtitle': 'CortexIDE is preparing your private, on-device coding assistant.',
+	'express.detecting': 'Detecting your hardware…',
+	'express.detected': 'Detected {0} GB of GPU memory.',
+	'express.detectedNoGPU': 'No discrete GPU detected — using a small model.',
+	'express.installPromptTitle': 'Install Ollama?',
+	'express.installPromptBody': 'CortexIDE will install Ollama, the local AI runtime, to run models privately on your computer. No data leaves your device.',
+	'express.installConfirm': 'Install Ollama',
+	'express.installDecline': 'Use a free cloud key instead',
+	'express.installing': 'Installing Ollama…',
+	'express.pulling': 'Downloading {0}…',
+	'express.pullingPercent': 'Downloading {0} ({1}%)',
+	'express.ready': 'Ready! Local AI is set up.',
+	'express.startChatting': 'Start chatting',
+	'express.customize': 'Customize setup',
+	'express.fallbackTitle': 'Use a free cloud model',
+	'express.fallbackBody': 'No local install needed. Groq offers a free API tier with fast Llama models. Get a key (takes 60 seconds), paste it below, and you are ready.',
+	'express.openGroqKeyPage': 'Open Groq key page',
+	'express.pasteKeyPlaceholder': 'Paste your Groq API key here (starts with gsk_…)',
+	'express.useGroqKey': 'Continue with Groq',
+	'express.invalidKey': 'That key does not look right. Groq keys start with "gsk_".',
+	'express.error.installFailed': 'Ollama install failed. You can use a free cloud key instead.',
+	'express.error.pullFailed': 'Model download failed. You can retry or use a free cloud key instead.',
+	'express.retry': 'Retry',
+	'express.useCloudInstead': 'Use a free cloud key instead',
+	'express.dismiss': 'Skip for now',
+
+	// allow-any-unicode-next-line
 	// ── Chat / Sidebar ───────────────────────────────────────────────────────
 	'chat.placeholder': 'Ask CortexIDE anything…',
 	'chat.placeholderAgent': 'Describe a task for the agent…',


### PR DESCRIPTION
## Overview

Adds a zero-friction express onboarding path so a fresh user can go from first launch to a working chat in roughly 90 seconds without touching settings. On a genuine first launch (no provider configured, onboarding incomplete) CortexIDE now renders a single panel that auto-detects hardware, asks one Yes/No to install Ollama, and pulls the hardware-recommended model pack. If Ollama install is declined or fails, the user lands on a single Groq free-tier fallback page (deep-link button + paste box). The legacy multi-step wizard is preserved exactly as is and remains reachable via a "Customize setup" link, so power users lose nothing.

## New files

- `src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/ExpressOnboardingFlow.tsx` — express path React component (detect, install confirmation, pull-with-progress, ready, Groq fallback, error/retry).

## Modified files

- `src/vs/workbench/contrib/cortexide/browser/react/src/onboarding/VoidOnboarding.tsx` — chooses Express vs legacy wizard based on `!isOnboardingComplete && !hasAnyProvider`; persists `isOnboardingComplete` when the express overlay is dismissed.
- `src/vs/workbench/contrib/cortexide/common/i18n/i18nService.ts` — adds canonical English keys consumed by the express UI (toast, install confirm, pull/progress, Groq fallback, errors).

## Existing services wired into (no reimplementation)

- `IOllamaInstallerService` — used for `getHardwareInfo()`, `isOllamaRunning()`, `install({ method: 'auto' })`, `pullModel(tag)`, and the `onPullProgress` / `onDone` event streams. Express path adds no new install logic.
- `ICortexideSettingsService` — used to add the pulled Ollama model, set it as the active Chat model, persist a user-pasted Groq key, and flip `isOnboardingComplete`. No managed keys are introduced.
- `ILocalSetupService` and the existing `LocalSetupWizard` — surfaced behind the "Customize setup" link so power users keep the full guided path.
- `ICortexideI18nService` via the existing `useTranslation()` hook — every new user-facing string flows through `t(key)`.

## What was deliberately NOT touched

- Agent loop, tools, prompts (`common/prompt/prompts.ts`).
- Provider registry (`common/modelCapabilities.ts`) — Groq is already a configured provider; this PR only stores a user-supplied key against it.
- No new npm dependencies.
- No telemetry events fired from the new component (privacy-first).
- No changes to the existing `VoidOnboardingContent` multi-step wizard — it still renders verbatim once the user has any configured provider, or when "Customize setup" is clicked.

## Verification

| Check | Result |
| --- | --- |
| `npm run compile-check-ts-native` | Pass (clean) |
| `npm run buildreact` (`out/onboarding/index.js`) | Pass (1.66 MB ESM) |
| `npm run valid-layers-check` | No new violations introduced by this PR — all reported warnings reference pre-existing files (`metricsService.ts`, `mcpService.ts`, `ollamaInstallerService.ts` etc.) on `main` |
| Pre-commit hygiene (husky) | Pass on all 3 commits |
| End-to-end runtime (sandbox) | Not run — see manual test plan below |

## Manual test plan

Because the React runtime can't be exercised in the sandbox, please verify the following manually after building the Electron app.

### Scenario A — fresh install with Ollama already present (any OS)
1. Wipe `IStorageService` for the `VOID_SETTINGS_STORAGE_KEY` (or run in a fresh user-data-dir).
2. Make sure the Ollama daemon is running (`curl http://127.0.0.1:11434/api/tags` returns 200).
3. Launch CortexIDE.
4. Expect: the express panel appears, briefly shows "Detecting your hardware…", then skips straight to "Downloading qwen2.5-coder:7b…" (or whatever pack matches detected VRAM) with a live progress bar.
5. When pull finishes: panel transitions to "Ready! Local AI is set up." with a "Start chatting" button.
6. Click "Start chatting". Overlay fades; settings show `isOnboardingComplete: true`, Chat model = `ollama / qwen2.5-coder:<size>`.

### Scenario B — fresh install with Ollama absent (macOS / Linux / Windows)
1. Same wiped state, but no Ollama daemon running.
2. Launch CortexIDE.
3. Expect: express panel shows the hardware badge plus "Install Ollama?" body with two buttons: "Install Ollama" and "Use a free cloud key instead".
4. Click "Install Ollama". Phase becomes "Installing Ollama…". On macOS this kicks off Homebrew + `open -a Ollama`; on Linux it runs the official `install.sh`; on Windows it uses winget or choco. (Existing installer behavior — unchanged by this PR.)
5. After daemon is reachable (up to 15s poll), pull phase begins. Same outcome as Scenario A.

### Scenario C — user declines install (Groq fallback)
1. Same wiped state, no Ollama daemon.
2. Express panel shows install prompt. Click "Use a free cloud key instead".
3. Expect: phase switches to Groq fallback panel: explanation, "Open Groq key page" button (opens `https://console.groq.com/keys` in default browser), password-style paste input, and a "Continue with Groq" button (disabled until input non-empty).
4. Paste an invalid string. Click "Continue with Groq". Expect inline error "That key does not look right. Groq keys start with 'gsk_'." Button remains enabled but submission rejected.
5. Paste a valid-looking key (e.g. `gsk_abc...`). Click "Continue with Groq". Expect: phase transitions to ready, overlay closes when "Start chatting" is clicked. Settings: Groq `apiKey` set, Chat model = `groq / llama-3.3-70b-versatile`.

### Scenario D — install fails
1. Force install failure (e.g. revoke shell perms, or kill the installer mid-flight).
2. Expect: panel shows "Ollama install failed. You can use a free cloud key instead." with "Retry" and "Use a free cloud key instead" buttons.
3. "Retry" re-runs `installOllama`. "Use a free cloud key instead" jumps to the Groq fallback.

### Scenario E — power-user escape hatch
1. From any phase of the express panel, click the "Customize setup" link in the footer.
2. Expect: the full existing `LocalSetupWizard` renders inside the same overlay (system check, model pack selection, verification, defaults). Completing or dismissing it returns to / closes the overlay as before.

### Scenario F — already-configured user (no regression)
1. Pre-populate settings with any configured provider (e.g. set `anthropic.apiKey`).
2. Launch CortexIDE with `isOnboardingComplete = false`.
3. Expect: the original `VoidOnboardingContent` multi-page wizard renders, **not** the express path. Confirms the existing flow is untouched.

## Confirmation

- Existing wizard reachable: yes (via "Customize setup" link and via fallback when any provider is already configured).
- Existing settings respected: yes (express path writes via `ICortexideSettingsService.setSettingOfProvider` / `setModelSelectionOfFeature` / `setGlobalSetting`, same path as the legacy wizard).
- No merge attempted, no `--ready` flag, opened as draft.
- No new providers introduced.
- Agent loop, tools, and `prompts.ts` untouched.

## Open questions / decisions punted

1. **Groq default model.** Hardcoded to `llama-3.3-70b-versatile` (large versatile free-tier). If the recommended Groq starter changes (e.g. to llama-4 scout), update `GROQ_DEFAULT_MODEL` at the top of `ExpressOnboardingFlow.tsx`.
2. **Groq key validation.** Currently a simple `gsk_` prefix + length>=20 check. A real validate-by-calling-Groq would be ideal but adds a network round-trip and a failure-mode UI we'd need to design — punted.
3. **`isOnboardingComplete` on dismiss.** The "Skip for now" button currently marks onboarding complete to prevent the overlay reappearing on next launch. If you'd rather have it reappear until the user makes a real choice, flip the dismiss handler in `VoidOnboarding.tsx`.
4. **Per-locale translations.** Only added English strings (canonical). All other locales (`zh`, `es`, `fr`, etc.) automatically fall back to English. If you want native strings for the express UI, those would be a separate translation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)