### PR TITLE
fix(tools): include_pattern key, terminal cap failure, dead comment

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/terminalToolService.ts
+++ b/src/vs/workbench/contrib/cortexide/browser/terminalToolService.ts
@@ -297,12 +297,11 @@ export class TerminalToolService extends Disposable implements ITerminalToolServ
 
 
 			const cmdCap = await this._waitForCommandDetectionCapability(terminal)
-			// if (!cmdCap) throw new Error(`There was an error using the terminal: CommandDetection capability did not mount yet. Please try again in a few seconds or report this to the Void team.`)
+			if (!cmdCap) throw new Error(`There was an error using the terminal: CommandDetection capability did not mount. Please try again in a few seconds or report this to the CortexIDE team.`)
 
 			// Prefer the structured command-detection capability when available
 
 			const waitUntilDone = new Promise<void>(resolve => {
-				if (!cmdCap) return
 				const l = cmdCap.onCommandFinished(cmd => {
 					if (resolveReason) return // already resolved
 					resolveReason = { type: 'done', exitCode: cmd.exitCode ?? 0 };

--- a/src/vs/workbench/contrib/cortexide/browser/toolsService.ts
+++ b/src/vs/workbench/contrib/cortexide/browser/toolsService.ts
@@ -254,7 +254,7 @@ export class ToolsService implements IToolsService {
 			search_pathnames_only: (params: RawToolParamsObj) => {
 				const {
 					query: queryUnknown,
-					search_in_folder: includeUnknown,
+					include_pattern: includeUnknown,
 					page_number: pageNumberUnknown
 				} = params
 

--- a/src/vs/workbench/contrib/cortexide/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/cortexide/common/prompt/prompts.ts
@@ -208,10 +208,6 @@ export const builtinTools: {
 		}
 	},
 
-	// pathname_search: {
-	// 	name: 'pathname_search',
-	// 	description: `Returns all pathnames that match a given \`find\`-style query over the entire workspace. ONLY searches file names. ONLY searches the current workspace. You should use this when looking for a file with a specific name or path. ${paginationHelper.desc}`,
-
 	search_pathnames_only: {
 		name: 'search_pathnames_only',
 		description: `Returns all pathnames that match a given query (searches ONLY file names). You should use this when looking for a file with a specific name or path.`,


### PR DESCRIPTION
## Summary
Three bugs from the 2026-05-25 tools audit, scoped as a small surgical PR.

- **B-01** `search_pathnames_only` destructured `search_in_folder` while the prompt advertises `include_pattern`. The filter was silently dropped on every call; the model thought it was scoping the search and got an unfiltered result.
- **B-02** `terminalToolService` had its `!cmdCap` throw commented out, so when `CommandDetection` failed to mount, `waitUntilDone` became a dead promise. The command silently timed out and stale terminal buffer contents were returned as if they were the command's output. Replaced with a clear throw — recoverable error beats silent garbage.
- **B-03** Dead `pathname_search` comment block left from a prior refactor — removed.

3 files changed, 2 insertions, 7 deletions.

## Test plan
- [ ] `search_pathnames_only` with `include_pattern: "**/*.ts"` filters results (regression test for B-01)
- [ ] Force a terminal without CommandDetection — confirm the error is now raised instead of returning stale buffer (B-02)
- [ ] `npm run compile-check-ts-native` passes
- [ ] No other call sites referenced the old `search_in_folder` key on this tool (verified by grep)

## Follow-ups (separate PRs, per audit §5)
- B-04 YOLO heuristic rewrite for `run_nl_command` (design call needed)
- B-05 honest descriptions for `extract_function` / `rename_symbol` / `automated_code_review` / `generate_tests`
- New tools: `multi_edit`, `glob_files`, `todo_write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)