### PR TITLE
fix(chat): drop per-thread caches on deleteThread to plug memory leak

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/chatThreadService.ts
+++ b/src/vs/workbench/contrib/cortexide/browser/chatThreadService.ts
@@ -5416,6 +5416,15 @@ We only need to do it for files that were edited since `from`, ie files between 
 			newCurrentId = newTabs[Math.max(0, closedIdx - 1)] ?? Object.keys(newThreads)[0] ?? ''
 		}
 
+		// Drop per-thread caches and state so deleted threads don't leak memory
+		// (file-read cache hits its 100-entry per-thread cap but the bucket itself was orphaned)
+		this._fileReadCache.delete(threadId)
+		this._fileReadCacheLRU.delete(threadId)
+		this._planCache.delete(threadId)
+		this._pendingStreamStateUpdates.delete(threadId)
+		delete this._suppressPlanOnceByThread[threadId]
+		delete this.streamState[threadId]
+
 		// store the updated threads
 		this._storeAllThreads(newThreads);
 		this._setState({ allThreads: newThreads, openTabs: newTabs, currentThreadId: newCurrentId })


### PR DESCRIPTION
## Summary
Follow-up to **B-07** in TOOLS_AUDIT_2026-05-25.

The audit flagged `_fileReadCache` as needing cap verification. Status:
- ✅ Cap exists: `MAX_FILE_READ_CACHE_ENTRIES_PER_THREAD = 100`, enforced with LRU eviction at chatThreadService.ts:2703
- ✅ Invalidated on `onDidFilesChange` (external edits)
- ✅ Invalidated on `edit_file` / `rewrite_file` / `delete_file_or_folder`
- ❌ **Never cleaned up when the owning thread is deleted** — the per-thread bucket is orphaned

The 100-entry cap bounds growth *within* a thread, but `deleteThread()` doesn't drop the bucket itself. Over a long session with many closed threads, that's ~one orphaned bucket per closed thread, each up to 100 file-read result entries.

Same pattern in five other per-thread structures, all keyed by `threadId`, none cleaned up on delete:

| Field | Type | What it holds |
|---|---|---|
| `_fileReadCache` | `Map<threadId, Map<key, ReadFileResult>>` | up to 100 entries × N closed threads |
| `_fileReadCacheLRU` | `Map<threadId, string[]>` | parallel LRU list |
| `_planCache` | `Map<threadId, PlanMessage \| null>` | plan + step state |
| `_suppressPlanOnceByThread` | `Record<threadId, boolean>` | small but unbounded |
| `_pendingStreamStateUpdates` | `Map<threadId, ThreadStreamState[..]>` | normally RAF-cleared but defensive cleanup is cheap |
| `streamState` | `Record<threadId, ThreadStreamState[..]>` | last LLM/tool stream snapshot |

Fix: six explicit deletes in `deleteThread()`. 9 insertions, no logic change.

## Audit follow-ups still open
- **B-04** YOLO heuristic rewrite for `run_nl_command` (design call needed)
- **B-06** `web_search` DDG scraping fragility (long-term)
- SSRF guard on `browse_url` (pairs with security review F-03)
- Option 2 epics from B-05: real `WorkspaceEdit`-based rename, Monaco-refactor-based extract, internal-LLM review/tests

## Test plan
- [ ] Open and delete ~20 threads, confirm `_fileReadCache.size` drops back to active-thread count (manual via devtools or a temporary log)
- [ ] `npm run compile-check-ts-native` passes
- [ ] No regression in normal thread-delete flow (UI stays responsive, current-thread reassignment still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)