### PR TITLE
fix(build): transpile watcher stages codicon.ttf so dev-mode icons render

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -535,7 +535,28 @@ async function compileStandaloneFiles(outDir: string, doMinify: boolean, target:
  * Used for development/transpile builds only - production bundles use
  * copyResources() with curated per-target patterns instead.
  */
+// codicon.ttf is shipped via node_modules, not committed to src/. The gulp `copy-codicons`
+// task normally stages it into src/ before transpile runs — but `watch-client-transpile`
+// (this entry point) doesn't depend on gulp, so a dev who only runs the transpile watcher
+// ends up with no icon font and the workbench renders every glyph as a tofu box. Ensure
+// the file is in src/ here so the glob below picks it up.
+function ensureCodiconFontStaged(): void {
+	const fontSrc = path.join(REPO_ROOT, 'node_modules', '@vscode', 'codicons', 'dist', 'codicon.ttf');
+	const fontDest = path.join(REPO_ROOT, SRC_DIR, 'vs', 'base', 'browser', 'ui', 'codicons', 'codicon', 'codicon.ttf');
+	if (fs.existsSync(fontDest)) {
+		return;
+	}
+	if (!fs.existsSync(fontSrc)) {
+		console.warn(`[codicons] codicon.ttf missing from node_modules — run "npm install" to fix icon rendering.`);
+		return;
+	}
+	fs.mkdirSync(path.dirname(fontDest), { recursive: true });
+	fs.copyFileSync(fontSrc, fontDest);
+	console.log(`[codicons] Staged codicon.ttf into ${path.relative(REPO_ROOT, fontDest)}`);
+}
+
 async function copyAllNonTsFiles(outDir: string, excludeTests: boolean): Promise<void> {
+	ensureCodiconFontStaged();
 	console.log(`[resources] Copying all non-TS files to ${outDir}...`);
 
 	const ignorePatterns = [


### PR DESCRIPTION
## Summary
`codicon.ttf` ships in `node_modules/@vscode/codicons/dist/` and is normally moved into `src/vs/base/browser/ui/codicons/codicon/` by gulp's `copy-codicons` task before transpile runs. The font file is `.gitignore`'d (correctly — it's a build artifact).

The `watch-client-transpile` entry point (`build/next/index.ts`) doesn't depend on gulp. So a dev who runs only:

```bash
npm run watch-client-transpile
./scripts/code.sh
```

(instead of the full `npm run watch`, which fans out to both) ends up with:
- no font in `src/`
- no font in `out/` (because `copyAllNonTsFiles` globs `src/**/*`)
- every workbench glyph rendering as a tofu box (□)

I hit this myself running the dev IDE this afternoon — the symptom is unambiguous and a fresh contributor would lose at least 20 minutes chasing it through Chromium's font-query logs before finding the gulp task.

## Fix
One idempotent helper `ensureCodiconFontStaged()` called from the top of `copyAllNonTsFiles()`:
- destination exists → no-op (the common case after first build)
- `node_modules` source missing → warn and continue (don't break the build over an icon)
- otherwise → copy once, log it

Cost per build cycle: one `fs.existsSync()` call.

1 file changed, +21 / -0.

## Test plan
- [x] Hygiene passes (was the second commit attempt; brace-style violation fixed)
- [ ] `rm -rf src/vs/base/browser/ui/codicons/codicon/codicon.ttf && npm run watch-client-transpile` — confirm `[codicons] Staged codicon.ttf into …` appears on the next build cycle
- [ ] `./scripts/code.sh` after the above — confirm workbench icons render correctly
- [ ] Re-run the watcher with the font already staged — confirm no log line and the build still succeeds (idempotent path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)