### PR TITLE
Phase 1 Sprint 2+3: design system and composer a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-browser": "npx playwright install && node test/unit/browser/index.js",
     "test-browser-no-install": "node test/unit/browser/index.js",
     "test-node": "mocha test/unit/node/index.js --delay --ui=tdd --timeout=5000 --exit",
-    "test-phase0-qa": "npm run test-node -- --runGlob \"**/cortexide/test/common/{providerSettingsValidation,onboardingHelpers,attachFileToChat,chatThreadStorageReviver,providerToolFormat,phase0ClaimVerification,modelCapabilities,menubarStackingFix}.test.js\"",
+    "test-phase0-qa": "npm run test-node -- --runGlob \"**/cortexide/test/common/{providerSettingsValidation,onboardingHelpers,attachFileToChat,chatThreadStorageReviver,providerToolFormat,phase0ClaimVerification,modelCapabilities,menubarStackingFix,designSystem}.test.js\"",
     "test-extension": "vscode-test",
     "test-build-scripts": "cd build && npm run test",
     "check-cyclic-dependencies": "node build/lib/checkCyclicDependencies.ts out",

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -17,6 +17,7 @@ import { PastThreadsList } from './SidebarThreadSelector.js';
 import { VoidChatArea, ButtonSubmit, ButtonStop } from './composer/VoidChatArea.js';
 import { SelectedFiles } from './composer/SelectedFiles.js';
 import { ScrollToBottomContainer } from './composer/ScrollToBottomContainer.js';
+import { ContextUsageBar } from './composer/ContextUsageBar.js';
 import { LandingPage } from './landing/LandingPage.js';
 import { ComposerTabs } from './chrome/ComposerTabs.js';
 import { ThreadHeader } from './chrome/ThreadHeader.js';
@@ -1164,17 +1165,12 @@ export const SidebarChat = () => {
 
 			{/* Context usage indicator */}
 			{modelSel ? (
-				(() => {
-					const pctNum = Math.max(0, Math.min(100, Math.round(contextPct * 100)))
-					const color = contextPct >= 1 ? 'text-[var(--cortex-danger)]' : contextPct > 0.8 ? 'text-[var(--cortex-warning)]' : 'text-void-fg-3'
-					const barColor = contextPct >= 1 ? 'bg-[var(--cortex-danger)]' : contextPct > 0.8 ? 'bg-[var(--cortex-warning)]' : 'bg-void-fg-3/60'
-					return <div className='mt-1'>
-						<div className={`text-[10px] ${color}`}>Context ~{contextTotal} / {contextBudget} tokens ({pctNum}%)</div>
-						<div className='h-[3px] w-full bg-void-border-3 rounded mt-0.5'>
-							<div className={`h-[3px] ${barColor} rounded`} style={{ width: `${pctNum}%` }} aria-label={`Context usage ${pctNum}%`} />
-						</div>
-					</div>
-				})()
+				<ContextUsageBar
+					className="mt-1"
+					contextTotal={contextTotal}
+					contextBudget={contextBudget}
+					contextPct={contextPct}
+				/>
 			) : null}
 		</div>
 	</div>
@@ -1183,17 +1179,12 @@ export const SidebarChat = () => {
 		<div className='pt-8'>
 			{inputChatArea}
 			{modelSel ? (
-				(() => {
-					const pctNum = Math.max(0, Math.min(100, Math.round(contextPct * 100)))
-					const color = contextPct >= 1 ? 'text-[var(--cortex-danger)]' : contextPct > 0.8 ? 'text-[var(--cortex-warning)]' : 'text-void-fg-3'
-					const barColor = contextPct >= 1 ? 'bg-[var(--cortex-danger)]' : contextPct > 0.8 ? 'bg-[var(--cortex-warning)]' : 'bg-void-fg-3/60'
-					return <div className='mt-1 px-2'>
-						<div className={`text-[10px] ${color}`}>Context ~{contextTotal} / {contextBudget} tokens ({pctNum}%)</div>
-						<div className='h-[3px] w-full bg-void-border-3 rounded mt-0.5'>
-							<div className={`h-[3px] ${barColor} rounded`} style={{ width: `${pctNum}%` }} aria-label={`Context usage ${pctNum}%`} />
-						</div>
-					</div>
-				})()
+				<ContextUsageBar
+					className="mt-1 px-2"
+					contextTotal={contextTotal}
+					contextBudget={contextBudget}
+					contextPct={contextPct}
+				/>
 			) : null}
 		</div>
 	</div>

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chat/UserMessageComponent.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chat/UserMessageComponent.tsx
@@ -215,36 +215,36 @@ export const UserMessageComponent = ({ chatMessage, messageIdx, isCheckpointGhos
 		onMouseEnter={() => setIsHovered(true)}
 		onMouseLeave={() => setIsHovered(false)}
 	>
-		<div
-			// style chatbubble according to role
-			className={`
-            text-left rounded-lg max-w-full
-            ${mode === 'edit' ? ''
-					: mode === 'display' ? 'p-2 flex flex-col bg-void-bg-1 text-void-fg-1 overflow-x-auto cursor-pointer' : ''
-				}
-        `}
-			onClick={() => { if (mode === 'display') { onOpenEdit() } }}
-		>
-			{chatbubbleContents}
-		</div>
+		{mode === 'display' ? (
+			<button
+				type="button"
+				className="text-left rounded-lg max-w-full p-2 flex flex-col bg-void-bg-1 text-void-fg-1 overflow-x-auto cursor-pointer void-focus-ring"
+				onClick={onOpenEdit}
+				aria-label="Edit message"
+			>
+				{chatbubbleContents}
+			</button>
+		) : (
+			<div className="text-left rounded-lg max-w-full">
+				{chatbubbleContents}
+			</div>
+		)}
 
 
 
 		<div
 			className="absolute -top-1 -right-1 translate-x-0 -translate-y-0 z-1"
-		// data-tooltip-id='cortex-tooltip'
-		// data-tooltip-content='Edit message'
-		// data-tooltip-place='left'
 		>
-			<EditSymbol
-				size={18}
+			<button
+				type="button"
 				className={`
                     cursor-pointer
                     p-[2px]
-                    bg-void-bg-1 border border-void-border-1 rounded-md
+                    bg-void-bg-1 border border-void-border-1 rounded-md void-focus-ring
                     transition-opacity duration-200 ease-in-out
                     ${isHovered || (isFocused && mode === 'edit') ? 'opacity-100' : 'opacity-0'}
                 `}
+				aria-label={mode === 'display' ? 'Edit message' : 'Close edit'}
 				onClick={() => {
 					if (mode === 'display') {
 						onOpenEdit()
@@ -252,7 +252,9 @@ export const UserMessageComponent = ({ chatMessage, messageIdx, isCheckpointGhos
 						onCloseEdit()
 					}
 				}}
-			/>
+			>
+				<EditSymbol size={18} aria-hidden="true" />
+			</button>
 		</div>
 
 

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ContextUsageBar.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ContextUsageBar.tsx
@@ -1,0 +1,51 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *--------------------------------------------------------------------------------------*/
+
+import React, { useId } from 'react';
+
+export type ContextUsageBarProps = {
+	contextTotal: number;
+	contextBudget: number;
+	contextPct: number;
+	className?: string;
+};
+
+export const ContextUsageBar = ({
+	contextTotal,
+	contextBudget,
+	contextPct,
+	className = '',
+}: ContextUsageBarProps) => {
+	const labelId = useId();
+	const pctNum = Math.max(0, Math.min(100, Math.round(contextPct * 100)));
+	const color = contextPct >= 1
+		? 'text-[var(--cortex-danger)]'
+		: contextPct > 0.8
+			? 'text-[var(--cortex-warning)]'
+			: 'text-void-fg-3';
+	const barColor = contextPct >= 1
+		? 'bg-[var(--cortex-danger)]'
+		: contextPct > 0.8
+			? 'bg-[var(--cortex-warning)]'
+			: 'bg-void-fg-3/60';
+
+	return (
+		<div className={className}>
+			<div className={`text-[10px] ${color}`} id={labelId}>
+				Context ~{contextTotal} / {contextBudget} tokens ({pctNum}%)
+			</div>
+			<div
+				className="h-[3px] w-full bg-void-border-3 rounded mt-0.5"
+				role="progressbar"
+				aria-labelledby={labelId}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				aria-valuenow={pctNum}
+			>
+				<div className={`h-[3px] ${barColor} rounded`} style={{ width: `${pctNum}%` }} />
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/VoidChatArea.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/VoidChatArea.tsx
@@ -390,12 +390,10 @@ export const VoidChatArea: React.FC<CortexideChatAreaProps> = ({
 			}}
 			className={`
 				gap-x-1
-                flex flex-col p-2.5 relative input text-left shrink-0
+                flex flex-col p-2.5 relative cortex-composer-shell text-left shrink-0
                 rounded-2xl
-                bg-[#030304]
 				transition-all duration-200
-				border border-[rgba(255,255,255,0.08)] focus-within:border-[rgba(255,255,255,0.12)] hover:border-[rgba(255,255,255,0.12)]
-				${isDragOver ? 'border-blue-500 bg-blue-500/10' : ''}
+				${isDragOver ? 'border-[var(--cortex-brand)] bg-[var(--cortex-brand-soft)]' : ''}
 				max-h-[80vh] overflow-y-auto
                 ${className}
             `}
@@ -483,12 +481,19 @@ export const VoidChatArea: React.FC<CortexideChatAreaProps> = ({
 
 				{/* Close button (X) if onClose is provided */}
 				{onClose && (
-					<div className='absolute -top-1 -right-1 cursor-pointer z-1'>
-						<IconX
-							size={12}
-							className="stroke-[2] opacity-80 text-void-fg-3 hover:brightness-95"
+					<div className='absolute -top-1 -right-1 z-1'>
+						<button
+							type="button"
+							className="cursor-pointer void-focus-ring rounded-md p-0.5"
 							onClick={onClose}
-						/>
+							aria-label="Close"
+						>
+							<IconX
+								size={12}
+								className="stroke-[2] opacity-80 text-void-fg-3 hover:brightness-95"
+								aria-hidden="true"
+							/>
+						</button>
 					</div>
 				)}
 			</div>
@@ -524,8 +529,8 @@ export const ButtonSubmit = ({ className, disabled, ...props }: ButtonProps & Re
 	return <button
 		type='button'
 		className={`rounded-full flex-shrink-0 flex-grow-0 flex items-center justify-center
-			button-press-animation
-			${disabled ? 'bg-vscode-disabled-fg cursor-default opacity-50' : 'bg-white cursor-pointer hover:bg-gray-50'}
+			btn btn-icon btn-submit button-press-animation
+			${disabled ? 'cursor-default' : 'cursor-pointer'}
 			${className}
 		`}
 		disabled={disabled}
@@ -542,7 +547,7 @@ export const ButtonSubmit = ({ className, disabled, ...props }: ButtonProps & Re
 export const ButtonStop = ({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => {
 	return <button
 		className={`rounded-full flex-shrink-0 flex-grow-0 cursor-pointer flex items-center justify-center
-			bg-white hover:bg-[var(--cortex-danger)]/5 button-press-animation
+			btn btn-icon btn-stop button-press-animation
 			${className}
 		`}
 		type='button'

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/SuggestedPrompts.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/SuggestedPrompts.tsx
@@ -12,15 +12,16 @@ const DEFAULT_PROMPTS = [
 ];
 
 export const SuggestedPrompts = ({ onSubmit }: { onSubmit: (text: string) => void }) => (
-	<div className='flex flex-col gap-2 w-full text-nowrap text-void-fg-3 select-none'>
+	<div className='flex flex-col gap-2 w-full text-nowrap select-none'>
 		{DEFAULT_PROMPTS.map((text, index) => (
-			<div
+			<button
 				key={index}
-				className='py-1 px-2 rounded text-sm bg-zinc-700/5 hover:bg-zinc-700/10 dark:bg-zinc-300/5 dark:hover:bg-zinc-300/10 cursor-pointer opacity-80 hover:opacity-100'
+				type="button"
+				className='btn btn-sm btn-secondary cortex-prompt-chip w-full text-left py-1 px-2 text-sm opacity-90 hover:opacity-100 void-focus-ring'
 				onClick={() => onSubmit(text)}
 			>
 				{text}
-			</div>
+			</button>
 		))}
 	</div>
 );

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolHeader.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolHeader.tsx
@@ -79,11 +79,21 @@ export const ToolHeaderWrapper = ({
 						{/* title eg "> Edited File" */}
 						<div className={`
 							flex items-center min-w-0 overflow-hidden grow
-							${isClickable ? 'cursor-pointer hover:brightness-125 transition-all duration-150' : ''}
+							${isClickable ? 'cursor-pointer hover:brightness-125 transition-all duration-150 void-focus-ring rounded-sm' : ''}
 						`}
+							role={isClickable ? 'button' : undefined}
+							tabIndex={isClickable ? 0 : undefined}
 							onClick={() => {
 								if (isDropdown) { setIsOpen(v => !v); }
 								if (onClick) { onClick(); }
+							}}
+							onKeyDown={(e) => {
+								if (!isClickable) return;
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									if (isDropdown) { setIsOpen(v => !v); }
+									if (onClick) { onClick(); }
+								}
 							}}
 						>
 							{isDropdown && (<ChevronRight
@@ -165,9 +175,18 @@ export const SimplifiedToolHeader = ({
 			<div className="w-full">
 				{/* header */}
 				<div
-					className={`select-none flex items-center min-h-[24px] ${isDropdown ? 'cursor-pointer' : ''}`}
+					className={`select-none flex items-center min-h-[24px] ${isDropdown ? 'cursor-pointer void-focus-ring rounded-sm' : ''}`}
+					role={isDropdown ? 'button' : undefined}
+					tabIndex={isDropdown ? 0 : undefined}
 					onClick={() => {
 						if (isDropdown) { setIsOpen(v => !v); }
+					}}
+					onKeyDown={(e) => {
+						if (!isDropdown) return;
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							setIsOpen(v => !v);
+						}
 					}}
 				>
 					{isDropdown && (

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/styles.css
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/styles.css
@@ -307,42 +307,142 @@
 	animation: token-count-pulse 0.3s ease-in-out;
 }
 
-/* html {
-	font-size: var(--vscode-font-size);
+/* ===========================================================================
+ * CortexIDE design system (Phase 1 Sprint 2)
+ * Scoped to .void-scope via Tailwind prefix pipeline.
+ * =========================================================================== */
+
+.void-scope .btn {
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--cortex-space-xs);
+	border-radius: var(--cortex-radius-md);
+	font-size: var(--cortex-font-body);
+	line-height: 1.2;
+	transition:
+		background-color var(--cortex-transition-base),
+		color var(--cortex-transition-base),
+		border-color var(--cortex-transition-base),
+		transform var(--cortex-transition-fast),
+		opacity var(--cortex-transition-base);
 }
 
-.btn {
-	@apply cursor-pointer transition-colors;
-
-	&.btn-primary {
-		@apply bg-vscode-button-bg text-vscode-button-fg;
-
-		&:not(:disabled) {
-			@apply hover:bg-vscode-button-hoverBg;
-		}
-	}
-
-	&.btn-sm {
-		@apply px-3 py-1 text-sm;
-	}
-
-	&.btn-secondary {
-		@apply bg-vscode-button-secondary-bg text-vscode-button-secondary-fg;
-
-		&:not(:disabled) {
-			@apply hover:bg-vscode-button-secondary-hoverBg;
-		}
-	}
-
-	&:disabled {
-		@apply opacity-75 cursor-not-allowed;
-	}
+.void-scope .btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
-.input {
-	@apply bg-vscode-input-bg text-vscode-input-fg border-vscode-input-border focus:outline-vscode-focus-border;
+.void-scope .btn-sm {
+	padding: var(--cortex-space-xs) var(--cortex-space-md);
+	font-size: var(--cortex-font-label);
 }
 
-.dropdown {
-	@apply bg-vscode-dropdown-bg text-vscode-dropdown-foreground border-vscode-dropdown-border focus:outline-vscode-focus-border;
-} */
+.void-scope .btn-primary {
+	background: var(--cortex-brand);
+	color: var(--cortex-btn-text);
+	border: 1px solid transparent;
+}
+
+.void-scope .btn-primary:not(:disabled):hover {
+	background: var(--cortex-brand-dim);
+}
+
+.void-scope .btn-secondary {
+	background: var(--cortex-surface-3);
+	color: var(--cortex-text-base);
+	border: 1px solid var(--cortex-border-base);
+}
+
+.void-scope .btn-secondary:not(:disabled):hover {
+	background: var(--cortex-surface-4);
+	border-color: var(--cortex-border-strong);
+}
+
+.void-scope .btn-ghost {
+	background: transparent;
+	color: var(--cortex-text-muted);
+	border: 1px solid transparent;
+}
+
+.void-scope .btn-ghost:not(:disabled):hover {
+	background: var(--cortex-surface-2-alt);
+	color: var(--cortex-text-strong);
+}
+
+.void-scope .btn-icon {
+	border-radius: 9999px;
+	padding: 0;
+	flex-shrink: 0;
+}
+
+.void-scope .btn-submit {
+	background: var(--cortex-text-strong);
+	color: var(--cortex-surface-1);
+	border: 1px solid transparent;
+}
+
+.void-scope .btn-submit:not(:disabled):hover {
+	opacity: 0.92;
+}
+
+.void-scope .btn-stop {
+	background: var(--cortex-surface-3);
+	color: var(--cortex-danger);
+	border: 1px solid var(--cortex-border-base);
+}
+
+.void-scope .btn-stop:not(:disabled):hover {
+	background: color-mix(in srgb, var(--cortex-danger) 8%, var(--cortex-surface-3));
+	border-color: color-mix(in srgb, var(--cortex-danger) 35%, var(--cortex-border-base));
+}
+
+body.vscode-light .void-scope .btn-submit {
+	background: var(--cortex-brand);
+	color: var(--cortex-btn-text);
+}
+
+body.vscode-light .void-scope .btn-submit:not(:disabled):hover {
+	background: var(--cortex-brand-dim);
+}
+
+.void-scope .input,
+.void-scope .cortex-composer-shell {
+	background: var(--cortex-surface-2);
+	color: var(--cortex-text-base);
+	border: 1px solid var(--cortex-border-weak);
+	border-radius: var(--cortex-radius-xl);
+	transition: border-color var(--cortex-transition-base), box-shadow var(--cortex-transition-base);
+}
+
+.void-scope .input:focus-within,
+.void-scope .cortex-composer-shell:focus-within {
+	border-color: var(--cortex-border-strong);
+	box-shadow: 0 0 0 1px color-mix(in srgb, var(--cortex-brand) 25%, transparent);
+}
+
+.void-scope .cortex-prompt-chip {
+	background: color-mix(in srgb, var(--cortex-surface-3) 65%, transparent);
+	color: var(--cortex-text-muted);
+	border: 1px solid var(--cortex-border-weak);
+	border-radius: var(--cortex-radius-md);
+}
+
+.void-scope .cortex-prompt-chip:not(:disabled):hover {
+	background: var(--cortex-surface-3);
+	color: var(--cortex-text-base);
+	border-color: var(--cortex-border-base);
+}
+
+.void-scope .dropdown {
+	background: var(--cortex-surface-3);
+	color: var(--cortex-text-base);
+	border: 1px solid var(--cortex-border-base);
+	border-radius: var(--cortex-radius-sm);
+}
+
+.void-scope .dropdown:focus-visible {
+	outline: 1px solid var(--cortex-ring-color);
+	outline-offset: 1px;
+}

--- a/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
+++ b/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
@@ -1,0 +1,49 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *--------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { suite, test } from 'mocha';
+
+/**
+ * CSS contract for Phase 1 Sprint 2 design system classes.
+ */
+const stylesPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/styles.css');
+const styles = readFileSync(stylesPath, 'utf8');
+
+const hasRule = (pattern: RegExp) => pattern.test(styles);
+
+suite('designSystem (Phase 1 Sprint 2 — composer tokens)', () => {
+
+	test('.btn-primary uses cortex brand tokens', () => {
+		assert.ok(
+			hasRule(/\.void-scope\s+\.btn-primary\s*\{[^}]*background:\s*var\(--cortex-brand\)/s),
+			'expected .void-scope .btn-primary to use --cortex-brand',
+		);
+	});
+
+	test('.btn-submit is theme-aware (light override)', () => {
+		assert.ok(
+			hasRule(/body\.vscode-light\s+\.void-scope\s+\.btn-submit/s),
+			'expected light-theme submit button override',
+		);
+	});
+
+	test('.cortex-composer-shell uses cortex surface tokens', () => {
+		assert.ok(
+			hasRule(/\.void-scope\s+\.cortex-composer-shell\s*\{[^}]*background:\s*var\(--cortex-surface-2\)/s),
+			'expected composer shell background token',
+		);
+	});
+
+	test('.input uses cortex border tokens', () => {
+		assert.ok(
+			hasRule(/\.void-scope\s+\.input[^}]*border:\s*1px solid var\(--cortex-border-weak\)/s),
+			'expected input border token',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
Completes **Phase 1 Sprint 2 (design system)** and **Sprint 3 (a11y)** for the chat composer shell.

### Sprint 2 — Design system
- Activate `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-submit`, `.btn-stop`, `.input`, `.dropdown`, `.cortex-composer-shell` in `styles.css` using `--cortex-*` tokens
- Theme-aware submit button (dark: high-contrast pill; light: brand purple)
- Replace hardcoded `#030304` / `bg-white` in `VoidChatArea` with design-system classes
- Suggested prompts use `.btn-secondary` + `.cortex-prompt-chip`
- Add `designSystem.test.ts` CSS contract (4 checks) → `test-phase0-qa` now **92 tests**

### Sprint 3 — Accessibility
- **`ContextUsageBar`** — proper `role="progressbar"` with `aria-valuenow/min/max`
- **Suggested prompts** — `div` → `button`
- **User message bubble** — clickable bubble + edit control are real buttons with labels
- **Composer close (X)** — button with `aria-label`
- **Tool headers** — keyboard support (`Enter`/`Space`) + `role="button"` on collapsible headers

## Test plan
- [x] `npm run buildreact`
- [x] `npm run test-phase0-qa` — 92 passing
- [ ] Manual: dark + light theme — composer input, submit/stop icons readable
- [ ] Manual: Tab to suggested prompts / edit message / tool headers; activate with Enter
- [ ] Manual: context usage bar announced by screen reader as progressbar


Made with [Cursor](https://cursor.com)