### PR TITLE
fix(cortexide): correct sidebar React bundle import paths for dev launch

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chrome/ComposerTabs.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chrome/ComposerTabs.tsx
@@ -5,7 +5,7 @@
 
 import { LoaderCircle, Plus, X } from 'lucide-react';
 import { useAccessor, useChatThreadsState, useFullChatThreadsStreamState } from '../../util/services.js';
-import type { IsRunningType } from '../../../../chatThreadService.js';
+import type { IsRunningType } from '../../../chatThreadService.js';
 import { getThreadTabLabel } from '../../../../common/threadTitle.js';
 
 const MAX_VISIBLE_TABS = 12;

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chrome/ThreadHeader.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/chrome/ThreadHeader.tsx
@@ -5,7 +5,7 @@
 
 import { History, Settings2 } from 'lucide-react';
 import { useAccessor, useChatThreadsState } from '../../util/services.js';
-import { CORTEXIDE_OPEN_SETTINGS_ACTION_ID } from '../../../../cortexideSettingsPane.js';
+import { CORTEXIDE_OPEN_SETTINGS_ACTION_ID } from '../../../cortexideSettingsPane.js';
 import { getThreadTabLabel } from '../../../../common/threadTitle.js';
 
 type ThreadHeaderProps = {

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/SelectedFiles.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/SelectedFiles.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { File, Folder, Text } from 'lucide-react';
-import { URI } from '../../../../../../../../base/common/uri.js';
+import { URI } from '../../../../../../../base/common/uri.js';
 import { useAccessor, useActiveURI } from '../../util/services.js';
 import { StagingSelectionItem } from '../../../../../common/chatThreadServiceTypes.js';
 import { IconX } from '../shared/icons.js';

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/LandingPage.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/LandingPage.tsx
@@ -5,7 +5,7 @@
 
 import React, { ReactNode, RefObject } from 'react';
 import { useMemo } from 'react';
-import { FileAccess } from '../../../../../../../../base/common/network.js';
+import { FileAccess } from '../../../../../../../base/common/network.js';
 import ErrorBoundary from '../ErrorBoundary.js';
 import { PastThreadsList } from '../SidebarThreadSelector.js';
 import { ContextChipsBar } from './ContextChipsBar.js';

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/QuickActionsBar.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/landing/QuickActionsBar.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { useAccessor } from '../../util/services.js';
-import { ICommandService } from '../../../../../../../../platform/commands/common/commands.js';
+import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 
 const QUICK_ACTIONS: { id: string; label: string }[] = [
 	{ id: 'void.explainCode', label: 'Explain' },

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolRenderers.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolRenderers.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronRight, AlertTriangle, Ban, Check, Dot, FileIcon, Folder, Text, Undo2, X } from 'lucide-react';
-import { URI } from '../../../../../../../../base/common/uri.js';
+import { URI } from '../../../../../../../base/common/uri.js';
 import { useAccessor, useChatThreadsState, useChatThreadsStreamState, useSettingsState } from '../../util/services.js';
 import { ChatMarkdownRender, getApplyBoxId } from '../../markdown/ChatMarkdownRender.js';
 import { VoidDiffEditor } from '../../util/inputs.js';
@@ -17,7 +17,7 @@ import { isABuiltinToolName, MAX_FILE_CHARS_PAGE, MAX_TERMINAL_INACTIVE_TIME } f
 import { RawToolCallObj } from '../../../../common/sendLLMMessageTypes.js';
 import { persistentTerminalNameOfId } from '../../../terminalToolService.js';
 import { removeMCPToolNamePrefix } from '../../../../common/mcpServiceTypes.js';
-import { ICommandService } from '../../../../../../../../platform/commands/common/commands.js';
+import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IconLoading } from '../shared/icons.js';
 import { getBasename, getFolderName, getRelative, voidOpenFileFn } from '../shared/pathUtils.js';
 import { ToolChildrenWrapper, CodeChildren, ListableToolItem } from './ToolPrimitives.js';


### PR DESCRIPTION
## Summary
- Fix relative import paths in extracted sidebar React modules (`chrome/`, `landing/`, `composer/`, `tools/`) that used one extra `../` segment after Phase 1 modularization
- tsup bundles all sidebar code into `sidebar-tsx/index.js`, so imports must be relative to that entry depth — the bad paths caused `Failed to fetch dynamically imported module: workbench.desktop.main.js` in developer mode

## Test plan
- [x] `npm run buildreact`
- [x] `./scripts/code.sh` — workbench loads, extension host starts
- [x] `npm run test-phase0-qa` — 92/92 passing


Made with [Cursor](https://cursor.com)