### PR TITLE
refactor(ui): extract ComposerInputArea and ComposerInputSection

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -7,15 +7,13 @@ import React, { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState
 
 import { useAccessor, useChatThreadsState, useChatThreadsStreamState, useSettingsState } from '../util/services.js';
 
-import { TextAreaFns, VoidInputBox2 } from '../util/inputs.js';
+import { TextAreaFns } from '../util/inputs.js';
 import { PastThreadsList } from './SidebarThreadSelector.js';
 import { VoidChatArea, ButtonSubmit, ButtonStop } from './composer/VoidChatArea.js';
 import { SelectedFiles } from './composer/SelectedFiles.js';
 import { scrollToBottom } from './composer/ScrollToBottomContainer.js';
-import { ContextUsageBar } from './composer/ContextUsageBar.js';
-import { CommandBarInChat } from './composer/CommandBarInChat.js';
 import { ChatMessageList } from './composer/ChatMessageList.js';
-import { StagingContextChips } from './composer/StagingContextChips.js';
+import { ComposerInputSection } from './composer/ComposerInputSection.js';
 import { useContextUsage } from './composer/useContextUsage.js';
 import { resolveAtReferencesInMessage } from '../../../../common/resolveAtReferences.js';
 import { handleSlashCommand } from './composer/handleSlashCommand.js';
@@ -31,8 +29,6 @@ import ErrorBoundary from './ErrorBoundary.js';
 import { useImageAttachments } from '../util/useImageAttachments.js';
 import { usePDFAttachments } from '../util/usePDFAttachments.js';
 import { useTranslation } from '../util/useTranslation.js';
-import { PDFAttachmentList } from '../util/PDFAttachmentList.js';
-import { ImageAttachmentList } from '../util/ImageAttachmentList.js';
 import { IconX, IconWarning, IconLoading, TypingCursor } from './shared/icons.js';
 import { getBasename, getFolderName, getRelative, voidOpenFileFn } from './shared/pathUtils.js';
 import { ToolChildrenWrapper, CodeChildren, ListableToolItem } from './tools/ToolPrimitives.js';
@@ -260,116 +256,54 @@ export const SidebarChat = () => {
 		scrollToBottomCallback={scrollToBottomCallback}
 	/>
 
-	const inputChatArea = <VoidChatArea
-		featureName='Chat'
-		onSubmit={() => onSubmit()}
-		onAbort={onAbort}
-		isStreaming={isActivelyStreaming}
-		isDisabled={isDisabled}
-		showSelections={true}
-		// showProspectiveSelections={previousMessagesHTML.length === 0}
-		selections={selections}
-		setSelections={setSelections}
-		onClickAnywhere={() => { textAreaRef.current?.focus() }}
-		imageAttachments={
-			imageAttachments.length > 0 ? (
-				<>
-					<ImageAttachmentList
-						attachments={imageAttachments}
-						onRemove={removeImage}
-						onRetry={retryImage}
-						onCancel={cancelImage}
-						focusedIndex={focusedImageIndex}
-						onFocusChange={setFocusedImageIndex}
-					/>
-					{imageValidationError && (
-						<div className="px-2 py-1 text-xs text-[var(--cortex-danger)] bg-[var(--cortex-danger)]/10 border border-[var(--cortex-danger)]/20 rounded-md mx-2">
-							{imageValidationError.message}
-						</div>
-					)}
-				</>
-			) : null
-		}
-		onImagePaste={addImages}
-		onImageDrop={addImages}
-		onPDFDrop={addPDFs}
-		pdfAttachments={
-			pdfAttachments.length > 0 ? (
-				<>
-					<PDFAttachmentList
-						attachments={pdfAttachments}
-						onRemove={removePDF}
-						onRetry={retryPDF}
-						onCancel={cancelPDF}
-						focusedIndex={focusedPDFIndex}
-						onFocusChange={setFocusedPDFIndex}
-					/>
-					{pdfValidationError && (
-						<div className="px-2 py-1 text-xs text-[var(--cortex-danger)] bg-[var(--cortex-danger)]/10 border border-[var(--cortex-danger)]/20 rounded-md mx-2">
-							{pdfValidationError}
-						</div>
-					)}
-				</>
-			) : null
-		}
-	>
-		<VoidInputBox2
-			enableAtToMention
-			appearance="chatDark"
-			className={`min-h-[60px] px-3 py-3 rounded-2xl`}
-			placeholder="Plan, @ for context"
-			onChangeText={onChangeText}
-			onKeyDown={onKeyDown}
-			onFocus={() => { chatThreadsService.setCurrentlyFocusedMessageIdx(undefined) }}
-			ref={textAreaRef}
-			fnsRef={textAreaFnsRef}
-			multiline={true}
+	const composerInputProps = {
+		onSubmit: () => onSubmit(),
+		onAbort,
+		isStreaming: isActivelyStreaming,
+		isDisabled,
+		selections,
+		setSelections,
+		textAreaRef,
+		textAreaFnsRef,
+		onChangeText,
+		onKeyDown,
+		onInputFocus: () => { chatThreadsService.setCurrentlyFocusedMessageIdx(undefined) },
+		onRemoveStagingLast: () => { chatThreadsService.popStagingSelections(1) },
+		imageAttachments,
+		removeImage,
+		retryImage,
+		cancelImage,
+		focusedImageIndex,
+		setFocusedImageIndex,
+		imageValidationError,
+		addImages,
+		pdfAttachments,
+		removePDF,
+		retryPDF,
+		cancelPDF,
+		focusedPDFIndex,
+		setFocusedPDFIndex,
+		pdfValidationError,
+		addPDFs,
+		modelSel,
+		contextTotal,
+		contextBudget,
+		contextPct,
+	};
+
+	const landingPageInput = (
+		<ComposerInputSection variant="landing" {...composerInputProps} />
+	);
+
+	const threadPageInput = (
+		<ComposerInputSection
+			variant="thread"
+			threadKey={chatThreadsState.currentThreadId}
+			{...composerInputProps}
 		/>
-
-		{/* Context chips for current selections */}
-		<StagingContextChips
-			selections={selections}
-			onRemoveLast={() => { chatThreadsService.popStagingSelections(1) }}
-		/>
-
-	</VoidChatArea>
-
+	);
 
 	const isLandingPage = previousMessages.length === 0
-
-
-	const threadPageInput = <div key={'input' + chatThreadsState.currentThreadId}>
-		<div className='px-4'>
-			<CommandBarInChat />
-		</div>
-		<div className='px-2 pb-2'>
-			{inputChatArea}
-
-			{/* Context usage indicator */}
-			{modelSel ? (
-				<ContextUsageBar
-					className="mt-1"
-					contextTotal={contextTotal}
-					contextBudget={contextBudget}
-					contextPct={contextPct}
-				/>
-			) : null}
-		</div>
-	</div>
-
-	const landingPageInput = <div>
-		<div className='pt-8'>
-			{inputChatArea}
-			{modelSel ? (
-				<ContextUsageBar
-					className="mt-1 px-2"
-					contextTotal={contextTotal}
-					contextBudget={contextBudget}
-					contextPct={contextPct}
-				/>
-			) : null}
-		</div>
-	</div>
 
 	const landingPageContent = <LandingPage
 		sidebarRef={sidebarRef}

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputArea.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputArea.tsx
@@ -1,0 +1,147 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *--------------------------------------------------------------------------------------*/
+
+import React, { KeyboardEvent, RefObject } from 'react';
+import { VoidChatArea } from './VoidChatArea.js';
+import { VoidInputBox2, TextAreaFns } from '../../util/inputs.js';
+import { StagingContextChips } from './StagingContextChips.js';
+import { ImageAttachmentList } from '../../util/ImageAttachmentList.js';
+import { PDFAttachmentList } from '../../util/PDFAttachmentList.js';
+import { StagingSelectionItem, ChatImageAttachment, ChatPDFAttachment } from '../../../../common/chatThreadServiceTypes.js';
+import { ImageValidationError } from '../../util/imageUtils.js';
+
+const AttachmentValidationBanner = ({ message }: { message: string }) => (
+	<div className="px-2 py-1 text-xs text-[var(--cortex-danger)] bg-[var(--cortex-danger)]/10 border border-[var(--cortex-danger)]/20 rounded-md mx-2">
+		{message}
+	</div>
+);
+
+export type ComposerInputAreaProps = {
+	onSubmit: () => void;
+	onAbort: () => void;
+	isStreaming: boolean;
+	isDisabled: boolean;
+	selections: StagingSelectionItem[];
+	setSelections: (selections: StagingSelectionItem[]) => void;
+	textAreaRef: RefObject<HTMLTextAreaElement | null>;
+	textAreaFnsRef: RefObject<TextAreaFns | null>;
+	onChangeText: (value: string) => void;
+	onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+	onInputFocus: () => void;
+	onRemoveStagingLast: () => void;
+	imageAttachments: ChatImageAttachment[];
+	removeImage: (id: string) => void;
+	retryImage: (id: string) => Promise<void>;
+	cancelImage: (id: string) => void;
+	focusedImageIndex: number | null;
+	setFocusedImageIndex: (index: number | null) => void;
+	imageValidationError: ImageValidationError | null;
+	addImages: (files: File[]) => Promise<void>;
+	pdfAttachments: ChatPDFAttachment[];
+	removePDF: (id: string) => void;
+	retryPDF: (id: string) => Promise<void>;
+	cancelPDF: (id: string) => void;
+	focusedPDFIndex: number | null;
+	setFocusedPDFIndex: (index: number | null) => void;
+	pdfValidationError: string | null;
+	addPDFs: (files: File[]) => Promise<void>;
+};
+
+export const ComposerInputArea = ({
+	onSubmit,
+	onAbort,
+	isStreaming,
+	isDisabled,
+	selections,
+	setSelections,
+	textAreaRef,
+	textAreaFnsRef,
+	onChangeText,
+	onKeyDown,
+	onInputFocus,
+	onRemoveStagingLast,
+	imageAttachments,
+	removeImage,
+	retryImage,
+	cancelImage,
+	focusedImageIndex,
+	setFocusedImageIndex,
+	imageValidationError,
+	addImages,
+	pdfAttachments,
+	removePDF,
+	retryPDF,
+	cancelPDF,
+	focusedPDFIndex,
+	setFocusedPDFIndex,
+	pdfValidationError,
+	addPDFs,
+}: ComposerInputAreaProps) => (
+	<VoidChatArea
+		featureName='Chat'
+		onSubmit={onSubmit}
+		onAbort={onAbort}
+		isStreaming={isStreaming}
+		isDisabled={isDisabled}
+		showSelections={true}
+		selections={selections}
+		setSelections={setSelections}
+		onClickAnywhere={() => { textAreaRef.current?.focus() }}
+		imageAttachments={
+			imageAttachments.length > 0 ? (
+				<>
+					<ImageAttachmentList
+						attachments={imageAttachments}
+						onRemove={removeImage}
+						onRetry={retryImage}
+						onCancel={cancelImage}
+						focusedIndex={focusedImageIndex}
+						onFocusChange={setFocusedImageIndex}
+					/>
+					{imageValidationError ? (
+						<AttachmentValidationBanner message={imageValidationError.message} />
+					) : null}
+				</>
+			) : null
+		}
+		onImagePaste={addImages}
+		onImageDrop={addImages}
+		onPDFDrop={addPDFs}
+		pdfAttachments={
+			pdfAttachments.length > 0 ? (
+				<>
+					<PDFAttachmentList
+						attachments={pdfAttachments}
+						onRemove={removePDF}
+						onRetry={retryPDF}
+						onCancel={cancelPDF}
+						focusedIndex={focusedPDFIndex}
+						onFocusChange={setFocusedPDFIndex}
+					/>
+					{pdfValidationError ? (
+						<AttachmentValidationBanner message={pdfValidationError} />
+					) : null}
+				</>
+			) : null
+		}
+	>
+		<VoidInputBox2
+			enableAtToMention
+			appearance="chatDark"
+			className="min-h-[60px] px-3 py-3 rounded-2xl"
+			placeholder="Plan, @ for context"
+			onChangeText={onChangeText}
+			onKeyDown={onKeyDown}
+			onFocus={onInputFocus}
+			ref={textAreaRef}
+			fnsRef={textAreaFnsRef}
+			multiline={true}
+		/>
+		<StagingContextChips
+			selections={selections}
+			onRemoveLast={onRemoveStagingLast}
+		/>
+	</VoidChatArea>
+);

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputSection.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputSection.tsx
@@ -1,0 +1,62 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *--------------------------------------------------------------------------------------*/
+
+import React from 'react';
+import { CommandBarInChat } from './CommandBarInChat.js';
+import { ContextUsageBar } from './ContextUsageBar.js';
+import { ComposerInputArea, ComposerInputAreaProps } from './ComposerInputArea.js';
+import { ModelSelection } from '../../../../common/cortexideSettingsTypes.js';
+
+type ComposerInputSectionProps = ComposerInputAreaProps & {
+	variant: 'landing' | 'thread';
+	threadKey?: string;
+	modelSel: ModelSelection | null | undefined;
+	contextTotal: number;
+	contextBudget: number;
+	contextPct: number;
+};
+
+export const ComposerInputSection = ({
+	variant,
+	threadKey,
+	modelSel,
+	contextTotal,
+	contextBudget,
+	contextPct,
+	...inputProps
+}: ComposerInputSectionProps) => {
+	const inputArea = <ComposerInputArea {...inputProps} />;
+	const contextBar = modelSel ? (
+		<ContextUsageBar
+			className={variant === 'landing' ? 'mt-1 px-2' : 'mt-1'}
+			contextTotal={contextTotal}
+			contextBudget={contextBudget}
+			contextPct={contextPct}
+		/>
+	) : null;
+
+	if (variant === 'thread') {
+		return (
+			<div key={'input' + (threadKey ?? '')}>
+				<div className='px-4'>
+					<CommandBarInChat />
+				</div>
+				<div className='px-2 pb-2'>
+					{inputArea}
+					{contextBar}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div className='pt-8'>
+				{inputArea}
+				{contextBar}
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary
- Extract `ComposerInputArea` — textarea, attachment lists, staging chips, validation banners
- Extract `ComposerInputSection` — landing vs thread layout, command bar, context usage bar
- `SidebarChat.tsx` down to **~364 lines** (from ~430)

## Test plan
- [x] `npm run buildreact`
- [x] `npm run test-phase0-qa` — 103/103
- [ ] Manual: landing page input + thread input both render; context bar shows when model selected


Made with [Cursor](https://cursor.com)