### PR TITLE
Phase 1: SidebarChat shell cleanup + staging chip fix

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -9,8 +9,6 @@ import { useAccessor, useChatThreadsState, useChatThreadsStreamState, useSetting
 
 import { TextAreaFns } from '../util/inputs.js';
 import { PastThreadsList } from './SidebarThreadSelector.js';
-import { VoidChatArea, ButtonSubmit, ButtonStop } from './composer/VoidChatArea.js';
-import { SelectedFiles } from './composer/SelectedFiles.js';
 import { scrollToBottom } from './composer/ScrollToBottomContainer.js';
 import { ChatMessageList } from './composer/ChatMessageList.js';
 import { ComposerInputSection } from './composer/ComposerInputSection.js';
@@ -29,22 +27,6 @@ import ErrorBoundary from './ErrorBoundary.js';
 import { useImageAttachments } from '../util/useImageAttachments.js';
 import { usePDFAttachments } from '../util/usePDFAttachments.js';
 import { useTranslation } from '../util/useTranslation.js';
-import { IconX, IconWarning, IconLoading, TypingCursor } from './shared/icons.js';
-import { getBasename, getFolderName, getRelative, voidOpenFileFn } from './shared/pathUtils.js';
-import { ToolChildrenWrapper, CodeChildren, ListableToolItem } from './tools/ToolPrimitives.js';
-import { ChatBubble } from './chat/ChatBubble.js';
-
-// Re-export shared modules for existing consumers (will migrate imports over time).
-export { IconX, IconWarning, IconLoading, TypingCursor } from './shared/icons.js';
-export { getBasename, getFolderName, getRelative, voidOpenFileFn } from './shared/pathUtils.js';
-export { ToolChildrenWrapper, CodeChildren, ListableToolItem } from './tools/ToolPrimitives.js';
-export { VoidChatArea, ButtonSubmit, ButtonStop } from './composer/VoidChatArea.js';
-export { SelectedFiles } from './composer/SelectedFiles.js';
-export { CommandBarInChat } from './composer/CommandBarInChat.js';
-export { ChatBubble } from './chat/ChatBubble.js';
-
-
-
 
 export const SidebarChat = () => {
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -268,7 +250,6 @@ export const SidebarChat = () => {
 		onChangeText,
 		onKeyDown,
 		onInputFocus: () => { chatThreadsService.setCurrentlyFocusedMessageIdx(undefined) },
-		onRemoveStagingLast: () => { chatThreadsService.popStagingSelections(1) },
 		imageAttachments,
 		removeImage,
 		retryImage,

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputArea.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/ComposerInputArea.tsx
@@ -30,7 +30,6 @@ export type ComposerInputAreaProps = {
 	onChangeText: (value: string) => void;
 	onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
 	onInputFocus: () => void;
-	onRemoveStagingLast: () => void;
 	imageAttachments: ChatImageAttachment[];
 	removeImage: (id: string) => void;
 	retryImage: (id: string) => Promise<void>;
@@ -61,7 +60,6 @@ export const ComposerInputArea = ({
 	onChangeText,
 	onKeyDown,
 	onInputFocus,
-	onRemoveStagingLast,
 	imageAttachments,
 	removeImage,
 	retryImage,
@@ -141,7 +139,7 @@ export const ComposerInputArea = ({
 		/>
 		<StagingContextChips
 			selections={selections}
-			onRemoveLast={onRemoveStagingLast}
+			onRemoveAt={(idx) => setSelections(selections.filter((_, i) => i !== idx))}
 		/>
 	</VoidChatArea>
 );

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/StagingContextChips.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/StagingContextChips.tsx
@@ -8,10 +8,10 @@ import { StagingSelectionItem } from '../../../../common/chatThreadServiceTypes.
 
 type StagingContextChipsProps = {
 	selections: StagingSelectionItem[];
-	onRemoveLast: () => void;
+	onRemoveAt: (index: number) => void;
 };
 
-export const StagingContextChips = ({ selections, onRemoveLast }: StagingContextChipsProps) => {
+export const StagingContextChips = ({ selections, onRemoveAt }: StagingContextChipsProps) => {
 	if (selections.length === 0) {
 		return null;
 	}
@@ -42,7 +42,7 @@ export const StagingContextChips = ({ selections, onRemoveLast }: StagingContext
 						<button
 							type="button"
 							className='btn btn-icon btn-ghost ml-1 text-void-fg-3 hover:text-void-fg-1'
-							onClick={onRemoveLast}
+							onClick={() => onRemoveAt(idx)}
 							aria-label={`Remove ${name}`}
 						>
 							×

--- a/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
+++ b/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
@@ -76,6 +76,8 @@ suite('designSystem (Phase 1 — onboarding adoption)', () => {
 
 const voidOnboardingPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/onboarding/VoidOnboarding.tsx');
 const settingsPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/settings/Settings.tsx');
+const sidebarChatPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/SidebarChat.tsx');
+const stagingContextChipsPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/composer/StagingContextChips.tsx');
 
 suite('designSystem (Phase 1 — void onboarding adoption)', () => {
 
@@ -96,5 +98,21 @@ suite('designSystem (Phase 1 — settings adoption)', () => {
 		assert.ok((src.match(/btn btn-secondary/g) ?? []).length >= 10, 'expected direct btn-secondary usage');
 		assert.ok(src.includes('btn-stop'), 'expected btn-stop for destructive Ollama delete');
 		assert.ok(src.includes("'dropdown "), 'expected dropdown class on Ollama selects');
+	});
+});
+
+suite('designSystem (Phase 1 — sidebar chat shell)', () => {
+
+	test('SidebarChat has no legacy re-exports', () => {
+		const src = readFileSync(sidebarChatPath, 'utf8');
+		assert.ok(!src.includes('Re-export shared modules'), 'SidebarChat should not re-export extracted modules');
+		assert.ok(!src.includes('export { IconX'), 'SidebarChat should not re-export icons');
+		assert.ok(src.includes('export const SidebarChat'), 'SidebarChat remains the sidebar entry component');
+	});
+
+	test('StagingContextChips removes by index', () => {
+		const src = readFileSync(stagingContextChipsPath, 'utf8');
+		assert.ok(src.includes('onRemoveAt'), 'expected index-based chip removal');
+		assert.ok(src.includes('onRemoveAt(idx)'), 'remove button should target clicked chip');
 	});
 });


### PR DESCRIPTION
## Summary
- Remove legacy re-export block from `SidebarChat.tsx` (~345 lines, thin shell only)
- Fix `StagingContextChips` so × removes the clicked chip (index-based) instead of always popping the last selection
- Extend `designSystem.test.ts` with guards for the thin shell and index-based chip removal

## Test plan
- [x] `npm run buildreact`
- [x] `npm run transpile-client` + `npm run test-phase0-qa` (108/108)
- [ ] Add multiple staging context chips → click × on middle chip → only that chip is removed


Made with [Cursor](https://cursor.com)