### PR TITLE
Phase 1: composer + tool-header design tokens

### DIFF
--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/CommandBarInChat.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/CommandBarInChat.tsx
@@ -184,10 +184,7 @@ export const CommandBarInChat = () => {
 			<div className='px-2'>
 				<div
 					className={`
-						select-none
-						flex w-full rounded-t-lg bg-void-bg-3
-						text-void-fg-3 text-xs text-nowrap
-
+						select-none cortex-tool-header-bar text-nowrap
 						overflow-hidden transition-all duration-200 ease-in-out
 						${isFileDetailsOpened ? 'max-h-24' : 'max-h-0'}
 					`}
@@ -195,17 +192,7 @@ export const CommandBarInChat = () => {
 					{fileDetailsContent}
 				</div>
 			</div>
-			<div
-				className={`
-					select-none
-					flex w-full rounded-t-lg bg-void-bg-3
-					text-void-fg-3 text-xs text-nowrap
-					border-t border-l border-r border-zinc-300/10
-
-					px-2 py-1
-					justify-between
-				`}
-			>
+			<div className="select-none cortex-tool-header-bar text-nowrap px-2 py-1 justify-between">
 				<div className="flex gap-2 items-center">
 					{fileDetailsButton}
 				</div>

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/VoidChatArea.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/composer/VoidChatArea.tsx
@@ -450,7 +450,7 @@ export const VoidChatArea: React.FC<CortexideChatAreaProps> = ({
 					<button
 						type="button"
 						onClick={handleImageUploadClick}
-						className="flex-shrink-0 p-1.5 rounded hover:bg-void-bg-2-alt text-void-fg-4 hover:text-void-fg-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+						className="cortex-composer-icon-btn"
 						aria-label="Upload images"
 						title="Upload images (or paste/drag & drop)"
 					>
@@ -461,7 +461,7 @@ export const VoidChatArea: React.FC<CortexideChatAreaProps> = ({
 					<button
 						type="button"
 						onClick={handlePDFUploadClick}
-						className="flex-shrink-0 p-1.5 rounded hover:bg-void-bg-2-alt text-void-fg-4 hover:text-void-fg-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+						className="cortex-composer-icon-btn"
 						aria-label="Upload PDFs"
 						title="Upload PDFs (or paste/drag & drop)"
 					>
@@ -499,11 +499,11 @@ export const VoidChatArea: React.FC<CortexideChatAreaProps> = ({
 			</div>
 
 			{/* Bottom row - Model selector and settings */}
-			<div className='flex flex-row justify-between items-center gap-2 mt-1 pt-1 border-t border-void-border-3/50'>
+			<div className='cortex-composer-toolbar flex flex-row justify-between items-center gap-2'>
 				{showModelDropdown && (
 					<div className='flex items-center flex-wrap gap-x-2 gap-y-1 text-nowrap flex-1 min-w-0'>
-						{featureName === 'Chat' && <ChatModeDropdown className='text-xs text-void-fg-3 bg-void-bg-1 border border-void-border-2 rounded py-0.5 px-1.5' />}
-						<ModelDropdown featureName={featureName} className='text-xs text-void-fg-3 bg-void-bg-1 rounded' />
+						{featureName === 'Chat' && <ChatModeDropdown className='cortex-composer-control' />}
+						<ModelDropdown featureName={featureName} className='cortex-composer-control' />
 						<ReasoningOptionSlider featureName={featureName} />
 					</div>
 				)}

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolHeader.tsx
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/sidebar-tsx/tools/ToolHeader.tsx
@@ -68,7 +68,7 @@ export const ToolHeaderWrapper = ({
 	>{desc1}</span>
 
 	return (<div className=''>
-		<div className={`w-full border border-void-border-3 rounded px-2 py-1 bg-void-bg-3 overflow-hidden ${className}`}>
+		<div className={`cortex-tool-header ${className ?? ''}`.trim()}>
 			{/* header */}
 			<div className={`select-none flex items-center min-h-[24px]`}>
 				<div className={`flex items-center w-full gap-x-2 overflow-hidden justify-between ${isRejected ? 'line-through' : ''}`}>

--- a/src/vs/workbench/contrib/cortexide/browser/react/src/styles.css
+++ b/src/vs/workbench/contrib/cortexide/browser/react/src/styles.css
@@ -492,3 +492,65 @@ body.vscode-light .void-scope .btn-submit:not(:disabled):hover {
 	border: 1px solid color-mix(in srgb, var(--cortex-warning) 30%, transparent);
 	border-radius: var(--cortex-radius-lg);
 }
+
+.void-scope .cortex-composer-toolbar {
+	border-top: 1px solid color-mix(in srgb, var(--cortex-border-weak) 50%, transparent);
+	padding-top: var(--cortex-space-xs);
+	margin-top: var(--cortex-space-xs);
+}
+
+.void-scope .cortex-composer-icon-btn {
+	flex-shrink: 0;
+	padding: var(--cortex-space-sm);
+	border-radius: var(--cortex-radius-sm);
+	color: var(--cortex-text-subtle);
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	transition:
+		background-color var(--cortex-transition-base),
+		color var(--cortex-transition-base);
+}
+
+.void-scope .cortex-composer-icon-btn:not(:disabled):hover {
+	background: var(--cortex-surface-2-alt);
+	color: var(--cortex-text-muted);
+}
+
+.void-scope .cortex-composer-icon-btn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+.void-scope .cortex-composer-control {
+	font-size: var(--cortex-font-label);
+	color: var(--cortex-text-muted);
+	background: var(--cortex-surface-1);
+	border: 1px solid var(--cortex-border-base);
+	border-radius: var(--cortex-radius-sm);
+	padding: 2px var(--cortex-space-sm);
+}
+
+.void-scope .cortex-tool-header {
+	width: 100%;
+	border: 1px solid var(--cortex-border-base);
+	border-radius: var(--cortex-radius-sm);
+	padding: var(--cortex-space-xs) var(--cortex-space-sm);
+	background: var(--cortex-surface-3);
+	color: var(--cortex-text-muted);
+	overflow: hidden;
+}
+
+.void-scope .cortex-tool-header-bar {
+	display: flex;
+	width: 100%;
+	border-top-left-radius: var(--cortex-radius-lg);
+	border-top-right-radius: var(--cortex-radius-lg);
+	background: var(--cortex-surface-3);
+	color: var(--cortex-text-muted);
+	font-size: var(--cortex-font-label);
+	padding: var(--cortex-space-xs) var(--cortex-space-sm);
+	border-top: 1px solid color-mix(in srgb, var(--cortex-border-weak) 40%, transparent);
+	border-left: 1px solid color-mix(in srgb, var(--cortex-border-weak) 40%, transparent);
+	border-right: 1px solid color-mix(in srgb, var(--cortex-border-weak) 40%, transparent);
+}

--- a/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
+++ b/src/vs/workbench/contrib/cortexide/test/common/designSystem.test.ts
@@ -78,6 +78,9 @@ const voidOnboardingPath = join(dirname(fileURLToPath(import.meta.url)), '../../
 const settingsPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/settings/Settings.tsx');
 const sidebarChatPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/SidebarChat.tsx');
 const stagingContextChipsPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/composer/StagingContextChips.tsx');
+const voidChatAreaPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/composer/VoidChatArea.tsx');
+const toolHeaderPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/tools/ToolHeader.tsx');
+const commandBarInChatPath = join(dirname(fileURLToPath(import.meta.url)), '../../browser/react/src/sidebar-tsx/composer/CommandBarInChat.tsx');
 
 suite('designSystem (Phase 1 — void onboarding adoption)', () => {
 
@@ -136,5 +139,35 @@ suite('designSystem (Phase 1 — sidebar chat shell)', () => {
 		const src = readFileSync(stagingContextChipsPath, 'utf8');
 		assert.ok(src.includes('onRemoveAt'), 'expected index-based chip removal');
 		assert.ok(src.includes('onRemoveAt(idx)'), 'remove button should target clicked chip');
+	});
+});
+
+suite('designSystem (Phase 1 — composer tool headers)', () => {
+
+	test('.cortex-tool-header uses cortex surface tokens', () => {
+		assert.ok(
+			hasRule(/\.void-scope\s+\.cortex-tool-header\s*\{[^}]*background:\s*var\(--cortex-surface-3\)/s),
+			'expected cortex-tool-header background token',
+		);
+		assert.ok(
+			hasRule(/\.void-scope\s+\.cortex-tool-header-bar\s*\{[^}]*background:\s*var\(--cortex-surface-3\)/s),
+			'expected cortex-tool-header-bar background token',
+		);
+	});
+
+	test('VoidChatArea composer footer uses design-system controls', () => {
+		const src = readFileSync(voidChatAreaPath, 'utf8');
+		assert.ok(src.includes('cortex-composer-toolbar'), 'expected composer toolbar class');
+		assert.ok(src.includes('cortex-composer-icon-btn'), 'expected composer icon button class');
+		assert.ok(src.includes('cortex-composer-control'), 'expected composer control class');
+		assert.ok(!src.includes('border-void-border-3/50'), 'toolbar should not use legacy void border');
+	});
+
+	test('Tool and command bar headers use cortex-tool-header tokens', () => {
+		const toolHeaderSrc = readFileSync(toolHeaderPath, 'utf8');
+		const commandBarSrc = readFileSync(commandBarInChatPath, 'utf8');
+		assert.ok(toolHeaderSrc.includes('cortex-tool-header'), 'ToolHeaderWrapper should use cortex-tool-header');
+		assert.ok(commandBarSrc.includes('cortex-tool-header-bar'), 'CommandBarInChat should use cortex-tool-header-bar');
+		assert.ok(!commandBarSrc.includes('bg-void-bg-3'), 'CommandBarInChat should not use legacy void background');
 	});
 });


### PR DESCRIPTION
## Summary
- Add `cortex-composer-toolbar`, `cortex-composer-icon-btn`, `cortex-composer-control`, `cortex-tool-header`, and `cortex-tool-header-bar` utilities
- Apply tokens in `VoidChatArea` (upload icons, model footer) and `CommandBarInChat` (diff bar)
- Migrate `ToolHeaderWrapper` shell to `cortex-tool-header`
- Extend `designSystem.test.ts` with CSS contract + adoption guards

## Test plan
- [x] `npm run buildreact`
- [x] `npm run transpile-client` + `npm run test-phase0-qa` (113/113)
- [ ] Open chat composer → verify model footer, image/PDF icons, and diff command bar styling
- [ ] Trigger a tool call → verify tool header card chrome


Made with [Cursor](https://cursor.com)