### PR TITLE
Phase 1: wire safety CDP verification into CI runner

### DIFF
--- a/.github/workflows/phase0-qa.yml
+++ b/.github/workflows/phase0-qa.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Phase 0 QA (unit + CDP)
+      - name: Run Phase 0 QA (unit + CDP + Phase 1 safety)
         run: test/cortexide-smoke/run-phase0-qa.sh --cdp
         env:
           CX_CDP_PORT: 9222
@@ -127,7 +127,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Phase 0 QA (unit + CDP)
+      - name: Run Phase 0 QA (unit + CDP + Phase 1 safety)
         shell: bash
         run: test/cortexide-smoke/run-phase0-qa.sh --cdp
         env:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-browser-no-install": "node test/unit/browser/index.js",
     "test-node": "mocha test/unit/node/index.js --delay --ui=tdd --timeout=5000 --exit",
     "test-phase0-qa": "npm run test-node -- --runGlob \"**/cortexide/test/common/{providerSettingsValidation,onboardingHelpers,attachFileToChat,chatThreadStorageReviver,providerToolFormat,phase0ClaimVerification,modelCapabilities,menubarStackingFix,designSystem,atReferenceTokens,resolveAtReferences,prepareChatAttachments}.test.js\"",
+    "test-phase1-safety-cdp": "node test/cortexide-smoke/phase1-safety-verify.mjs",
     "test-extension": "vscode-test",
     "test-build-scripts": "cd build && npm run test",
     "check-cyclic-dependencies": "node build/lib/checkCyclicDependencies.ts out",

--- a/test/cortexide-smoke/README.md
+++ b/test/cortexide-smoke/README.md
@@ -12,7 +12,11 @@ Chrome DevTools Protocol (CDP). Used to confirm the editor actually boots and it
   (`workbench-dev.html` in dev builds), and asserts core + CortexIDE surfaces exist.
 - `phase0-qa-verify.mjs` — CDP regression for merged Phase 0 fixes (PR #69): provider
   validation, local tool format, attach-file commands, menubar stacking, theme scoping.
-- `run-phase0-qa.sh` — runs `npm run test-phase0-qa` (unit) and optionally `--cdp` live verify.
+- `phase1-safety-verify.mjs` — CDP regression for Phase 1 safety: loads real transpiled
+  `toolPermissions` / `commandRisk` in the live renderer, exercises gather/agent/untrusted
+  decisions, and confirms `cortexide.*` safety settings registered at startup.
+- `run-phase0-qa.sh` — runs `npm run test-phase0-qa` (unit) and optionally `--cdp` live verify
+  (Phase 0 UI + Phase 1 safety).
 
 ## Usage
 ```bash
@@ -37,9 +41,14 @@ npm run test-phase0-qa
 node build/lib/preLaunch.ts
 npm run buildreact   # if you touched React UI
 test/cortexide-smoke/run-phase0-qa.sh --cdp
+
+# Phase 1 safety only (app must already be running on the CDP port):
+npm run test-phase1-safety-cdp
+# or: node test/cortexide-smoke/phase1-safety-verify.mjs --port 9222
 ```
 
 CI: `.github/workflows/phase0-qa.yml` runs unit tests on every PR/push to `main`.
+Manual CDP jobs (`run-phase0-qa.sh --cdp`) also run Phase 1 safety verification.
 Trigger CDP jobs manually via **Actions → Phase 0 QA → Run workflow**:
 - **Windows** job clicks the in-window menubar and verifies the dropdown is visible (release gate for #8).
 - **macOS** job runs module + CSS checks (native menu bar — no live click).

--- a/test/cortexide-smoke/run-phase0-qa.sh
+++ b/test/cortexide-smoke/run-phase0-qa.sh
@@ -5,6 +5,7 @@
 #---------------------------------------------------------------------------------------------
 #
 # Phase 0 QA runner — unit tests (always) + optional CDP smoke against a dev build.
+# When --cdp is set, also runs Phase 1 safety verification (tool permissions, command risk, config registry).
 #
 #  Usage:
 #    test/cortexide-smoke/run-phase0-qa.sh           # unit tests only
@@ -69,4 +70,7 @@ for i in {1..60}; do
 done
 
 node test/cortexide-smoke/phase0-qa-verify.mjs --port "$PORT"
-echo "Phase 0 QA (unit + CDP) complete."
+echo ""
+echo "== Phase 1 safety: CDP verify (port $PORT) =="
+node test/cortexide-smoke/phase1-safety-verify.mjs --port "$PORT"
+echo "Phase 0 QA + Phase 1 safety (unit + CDP) complete."


### PR DESCRIPTION
## Summary
- Chain `phase1-safety-verify.mjs` after `phase0-qa-verify.mjs` when `run-phase0-qa.sh --cdp` runs
- Add `npm run test-phase1-safety-cdp` for standalone runs against an already-running dev app
- Update smoke README and Phase 0 QA workflow step labels (macOS + Windows CDP jobs)

Phase 1 safety checks exercise real transpiled `toolPermissions` / `commandRisk` modules in the live renderer and confirm `cortexide.*` safety settings registered at startup.

## Test plan
- [x] `npm run test-phase0-qa` (113/113)
- [ ] Manual: launch dev app → `npm run test-phase1-safety-cdp -- --port 9222`
- [ ] Manual: Actions → Phase 0 QA → workflow_dispatch → macOS CDP job


Made with [Cursor](https://cursor.com)