### PR TITLE
Phase 2: wire agent-loop unit tests into CI

### DIFF
--- a/.github/workflows/phase0-qa.yml
+++ b/.github/workflows/phase0-qa.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Transpile source
         run: npm run transpile-client
 
-      - name: Run Phase 0 QA unit tests
-        run: npm run test-phase0-qa
+      - name: Run CortexIDE unit regression (Phase 0 + Phase 2)
+        run: npm run test-cortexide-qa
 
   phase0-cdp-macos:
     name: Phase 0 CDP smoke (macOS)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test-node": "mocha test/unit/node/index.js --delay --ui=tdd --timeout=5000 --exit",
     "test-phase0-qa": "npm run test-node -- --runGlob \"**/cortexide/test/common/{providerSettingsValidation,onboardingHelpers,attachFileToChat,chatThreadStorageReviver,providerToolFormat,phase0ClaimVerification,modelCapabilities,menubarStackingFix,designSystem,atReferenceTokens,resolveAtReferences,prepareChatAttachments}.test.js\"",
     "test-phase1-safety-cdp": "node test/cortexide-smoke/phase1-safety-verify.mjs",
+    "test-phase2-qa": "npm run test-node -- --runGlob \"**/cortexide/test/common/{agentLoopDecisions,toolPermissions,toolSynthesisDecision,toolCallRecognition}.test.js\"",
+    "test-cortexide-qa": "npm run test-phase0-qa && npm run test-phase2-qa",
     "test-extension": "vscode-test",
     "test-build-scripts": "cd build && npm run test",
     "check-cyclic-dependencies": "node build/lib/checkCyclicDependencies.ts out",

--- a/test/cortexide-smoke/README.md
+++ b/test/cortexide-smoke/README.md
@@ -35,7 +35,9 @@ Exit code 0 = all checks passed. A screenshot is written to the OS temp dir.
 
 ```bash
 # Fast — unit tests only (CI runs this on every PR):
-npm run test-phase0-qa
+npm run test-cortexide-qa
+# Phase 0 only: npm run test-phase0-qa
+# Phase 2 only: npm run test-phase2-qa
 
 # Full — unit tests + live CDP verify (needs a built dev app):
 node build/lib/preLaunch.ts

--- a/test/cortexide-smoke/run-phase0-qa.sh
+++ b/test/cortexide-smoke/run-phase0-qa.sh
@@ -27,8 +27,8 @@ PORT="${CX_CDP_PORT:-9222}"
 WS="${CX_WS:-/tmp/cx-phase0-qa-ws}"
 PROFILE="${CX_PROFILE:-/tmp/cx-phase0-qa-profile}"
 
-echo "== Phase 0 QA: unit tests =="
-npm run test-phase0-qa
+echo "== CortexIDE QA: Phase 0 + Phase 2 unit tests =="
+npm run test-cortexide-qa
 
 if [[ "$RUN_CDP" -ne 1 ]]; then
 	echo ""


### PR DESCRIPTION
## Summary
- Add `npm run test-phase2-qa` — 142 tests covering `agentLoopDecisions`, `toolPermissions`, `toolSynthesisDecision`, `toolCallRecognition`
- Add `npm run test-cortexide-qa` — chains Phase 0/1 (113) + Phase 2 (142) = **255** unit tests
- Update Phase 0 QA workflow + `run-phase0-qa.sh` to use the combined suite

Kicks off Phase 2 CI gating on the pure agent-loop decision logic already extracted from `chatThreadService`.

## Test plan
- [x] `npm run test-cortexide-qa` (255/255)
- [ ] CI Phase 0 QA unit job passes on this PR


Made with [Cursor](https://cursor.com)